### PR TITLE
Add E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ up-rebuild:$(DOCKER_COMPOSE_YAML)
 # Rebuild the docker image from scratch
 .PHONY:force-rebuild
 force-rebuild:$(DOCKER_COMPOSE_YAML)
-	$(DOCKER_COMPOSE) compose --file $(DOCKER_COMPOSE_YAML) build --no-cache
+	$(DOCKER_COMPOSE) compose --profile standalone --file $(DOCKER_COMPOSE_YAML) build --no-cache
 
 # Turn project off
 .PHONY:down

--- a/poetry.lock
+++ b/poetry.lock
@@ -1107,4 +1107,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "93e50c833a2d15f6026b4960cac37d536d307e89037e84a77f7292ba186a104e"
+content-hash = "f89a262c979f57e0122d2020e6ace36e84051631da50b47c955eadc4f95142d0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -273,6 +273,25 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "fakeredis"
+version = "2.17.0"
+description = "Python implementation of redis API, can be used for testing purposes."
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "fakeredis-2.17.0-py3-none-any.whl", hash = "sha256:a99ef6e5642c31e91d36be78809fec3743e2bf7aaa682685b0d65a849fecd148"},
+    {file = "fakeredis-2.17.0.tar.gz", hash = "sha256:e304bc7addb2f862c3550cb7db58548418a0fadd4cd78a4de66464c84fbc2195"},
+]
+
+[package.dependencies]
+redis = ">=4"
+sortedcontainers = ">=2,<3"
+
+[package.extras]
+json = ["jsonpath-ng (>=1.5,<2.0)"]
+lua = ["lupa (>=1.14,<2.0)"]
+
+[[package]]
 name = "fastapi"
 version = "0.96.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -318,6 +337,50 @@ files = [
     {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
     {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
 ]
+
+[[package]]
+name = "httpcore"
+version = "0.17.3"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "httpcore-0.17.3-py3-none-any.whl", hash = "sha256:c2789b767ddddfa2a5782e3199b2b7f6894540b17b16ec26b2c4d8e103510b87"},
+    {file = "httpcore-0.17.3.tar.gz", hash = "sha256:a6f30213335e34c1ade7be6ec7c47f19f50c56db36abef1a9dfa3815b1cb3888"},
+]
+
+[package.dependencies]
+anyio = ">=3.0,<5.0"
+certifi = "*"
+h11 = ">=0.13,<0.15"
+sniffio = "==1.*"
+
+[package.extras]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+
+[[package]]
+name = "httpx"
+version = "0.24.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "httpx-0.24.1-py3-none-any.whl", hash = "sha256:06781eb9ac53cde990577af654bd990a4949de37a28bdb4a230d434f3a30b9bd"},
+    {file = "httpx-0.24.1.tar.gz", hash = "sha256:5853a43053df830c20f8110c5e69fe44d035d850b2dfe795e196f00fdb774bdd"},
+]
+
+[package.dependencies]
+certifi = "*"
+httpcore = ">=0.15.0,<0.18.0"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "identify"
@@ -926,6 +989,17 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "starlette"
 version = "0.27.0"
 description = "The little ASGI library that shines."
@@ -1033,4 +1107,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "1a2168cc30d52212ad25ebbcc81c7512526ebd46342a2d2e2136cc3f16d91372"
+content-hash = "93e50c833a2d15f6026b4960cac37d536d307e89037e84a77f7292ba186a104e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ uvicorn = "^0.22.0"
 pika = "1.3.2"
 pandas = "^2.0.0"
 filelock = "^3.12.2"
+poethepoet = "^0.21.1"
 # juliacall = { version="^0.9.14", optional = true }
 
 [tool.poetry.scripts]
@@ -30,14 +31,14 @@ pytest = "^7.4.0"
 pre-commit = "^3.3.3"
 requests-mock = "^1.11.0"
 mock = "^5.1.0"
-poethepoet = "^0.21.1"
+fakeredis = "^2.17.0"
+httpx = "^0.24.1"
 
 [tool.poe.tasks]
 install-pyciemss = "pip install git+https://github.com/ciemss/pyciemss.git#c54cff8e301aa53239a9f0e789c8618c3c75569b" 
 
 [tool.pytest.ini_options]
-python_files = ["tests/tests.py"]
-markers = ["operation"]
+markers = ["example_dir"]
 pythonpath = "service"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ fakeredis = "^2.17.0"
 httpx = "^0.24.1"
 
 [tool.poe.tasks]
-install-pyciemss = "pip install git+https://github.com/ciemss/pyciemss.git#c54cff8e301aa53239a9f0e789c8618c3c75569b" 
+install-pyciemss = "pip install --no-cache git+https://github.com/ciemss/pyciemss.git@v0.0.1" 
 
 [tool.pytest.ini_options]
 markers = ["example_dir"]

--- a/service/api.py
+++ b/service/api.py
@@ -22,10 +22,6 @@ logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
 
 
-def enable_progress():
-    return True
-
-
 def build_api(*args) -> FastAPI:
     api = FastAPI(
         title="CIEMSS Service",
@@ -95,7 +91,6 @@ def operate(
     operation: str,
     body: Operation,
     redis_conn=Depends(get_redis),
-    progress_enabled=Depends(enable_progress),
 ) -> JobResponse:
     def check(otype):
         if isinstance(body, otype):
@@ -116,4 +111,4 @@ def operate(
             check(EnsembleCalibrate)
         case _:
             raise HTTPException(status_code=404, detail="Operation not found")
-    return create_job(body, operation, redis_conn, progress_enabled)
+    return create_job(body, operation, redis_conn)

--- a/service/api.py
+++ b/service/api.py
@@ -22,6 +22,10 @@ logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
 
 
+def enable_progress():
+    return True
+
+
 def build_api(*args) -> FastAPI:
     api = FastAPI(
         title="CIEMSS Service",
@@ -88,7 +92,10 @@ def cancel_job(
 
 @app.post("/{operation}", response_model=JobResponse)
 def operate(
-    operation: str, body: Operation, redis_conn=Depends(get_redis)
+    operation: str,
+    body: Operation,
+    redis_conn=Depends(get_redis),
+    progress_enabled=Depends(enable_progress),
 ) -> JobResponse:
     def check(otype):
         if isinstance(body, otype):
@@ -109,4 +116,4 @@ def operate(
             check(EnsembleCalibrate)
         case _:
             raise HTTPException(status_code=404, detail="Operation not found")
-    return create_job(body, operation, redis_conn)
+    return create_job(body, operation, redis_conn, progress_enabled)

--- a/service/execute.py
+++ b/service/execute.py
@@ -2,7 +2,6 @@ import logging
 
 # from juliacall import newmodule
 from settings import settings
-from utils.rabbitmq import gen_rabbitmq_hook
 from utils.tds import (
     update_tds_status,
     cleanup_job_dir,
@@ -30,19 +29,14 @@ logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
 
 
-def run(request, *, job_id, progress_enabled):
+def run(request, *, job_id):
     logging.debug(f"STARTED {job_id} (username: {request.username})")
     sim_results_url = TDS_URL + TDS_SIMULATIONS + job_id
     update_tds_status(sim_results_url, status="running", start=True)
 
     # if request.engine == "ciemss":
     operation_name = request.__class__.pyciemss_lib_function
-    if progress_enabled:
-        kwargs = request.gen_pyciemss_args(
-            job_id, progress_hook=gen_rabbitmq_hook(job_id)
-        )
-    else:
-        kwargs = request.gen_pyciemss_args(job_id)
+    kwargs = request.gen_pyciemss_args(job_id)
     if len(operation_name) == 0:
         raise Exception("No operation provided in request")
     else:

--- a/service/execute.py
+++ b/service/execute.py
@@ -2,6 +2,7 @@ import logging
 
 # from juliacall import newmodule
 from settings import settings
+from utils.rabbitmq import gen_rabbitmq_hook
 from utils.tds import (
     update_tds_status,
     cleanup_job_dir,
@@ -29,14 +30,19 @@ logging.basicConfig()
 logging.getLogger().setLevel(logging.DEBUG)
 
 
-def run(request, *, job_id):
+def run(request, *, job_id, progress_enabled):
     logging.debug(f"STARTED {job_id} (username: {request.username})")
     sim_results_url = TDS_URL + TDS_SIMULATIONS + job_id
     update_tds_status(sim_results_url, status="running", start=True)
 
     # if request.engine == "ciemss":
     operation_name = request.__class__.pyciemss_lib_function
-    kwargs = request.gen_pyciemss_args(job_id)
+    if progress_enabled:
+        kwargs = request.gen_pyciemss_args(
+            job_id, progress_hook=gen_rabbitmq_hook(job_id)
+        )
+    else:
+        kwargs = request.gen_pyciemss_args(job_id)
     if len(operation_name) == 0:
         raise Exception("No operation provided in request")
     else:

--- a/service/utils/rq_helpers.py
+++ b/service/utils/rq_helpers.py
@@ -40,7 +40,7 @@ def update_status_on_job_fail(job, connection, etype, value, traceback):
     logging.exception(log_message)
 
 
-def create_job(request_payload, sim_type, redis_conn):
+def create_job(request_payload, sim_type, redis_conn, progress_enabled=False):
     job_id = f"ciemss-{uuid4()}"
 
     post_url = TDS_URL + TDS_SIMULATIONS
@@ -68,7 +68,7 @@ def create_job(request_payload, sim_type, redis_conn):
     queue.enqueue_call(
         func="execute.run",
         args=[request_payload],
-        kwargs={"job_id": job_id},
+        kwargs={"job_id": job_id, "progress_enabled": progress_enabled},
         job_id=job_id,
         on_failure=update_status_on_job_fail,
     )

--- a/service/utils/rq_helpers.py
+++ b/service/utils/rq_helpers.py
@@ -40,7 +40,7 @@ def update_status_on_job_fail(job, connection, etype, value, traceback):
     logging.exception(log_message)
 
 
-def create_job(request_payload, sim_type, redis_conn, progress_enabled=False):
+def create_job(request_payload, sim_type, redis_conn):
     job_id = f"ciemss-{uuid4()}"
 
     post_url = TDS_URL + TDS_SIMULATIONS
@@ -68,7 +68,7 @@ def create_job(request_payload, sim_type, redis_conn, progress_enabled=False):
     queue.enqueue_call(
         func="execute.run",
         args=[request_payload],
-        kwargs={"job_id": job_id, "progress_enabled": progress_enabled},
+        kwargs={"job_id": job_id},
         job_id=job_id,
         on_failure=update_status_on_job_fail,
     )

--- a/service/utils/tds.py
+++ b/service/utils/tds.py
@@ -126,6 +126,13 @@ def attach_files(output: dict, tds_api, simulation_endpoint, job_id, status="com
             presigned_upload_url = upload_response.json()["url"]
             with open(location, "rb") as f:
                 upload_response = requests.put(presigned_upload_url, f)
+                if upload_response.status_code >= 300:
+                    raise Exception(
+                        (
+                            "Failed to upload file to TDS "
+                            f"(status: {upload_response.status_code}): {handle}"
+                        )
+                    )
     else:
         logging.error(f"{job_id} ran into error")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,17 +2,6 @@ import json
 import os
 
 import pytest
-from pydantic import BaseSettings
-
-
-class Environment(BaseSettings):
-    LIVE_REDIS: bool = False
-    LIVE_PYCIEMSS: bool = False
-
-
-@pytest.fixture
-def environment():
-    return Environment()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,32 +2,17 @@ import json
 import os
 
 import pytest
-from fastapi.testclient import TestClient
 from pydantic import BaseSettings
-from fakeredis import FakeStrictRedis
-from rq import Queue
-
-
-from service.api import app
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
 
 
 class Environment(BaseSettings):
-    IS_LIVE: bool = False
+    MOCK_REDIS: bool = True
+    MOCK_PYCIEMSS: bool = True
 
 
 @pytest.fixture
 def environment():
     return Environment()
-
-
-@pytest.fixture
-def redis_queue():
-    return Queue(is_async=False, connection=FakeStrictRedis())
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ from pydantic import BaseSettings
 
 
 class Environment(BaseSettings):
-    MOCK_REDIS: bool = True
-    MOCK_PYCIEMSS: bool = True
+    LIVE_REDIS: bool = False
+    LIVE_PYCIEMSS: bool = False
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,54 @@
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import BaseSettings
+from fakeredis import FakeStrictRedis
+from rq import Queue
+
+
+from service.api import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class Environment(BaseSettings):
+    IS_LIVE: bool = False
+
+
+@pytest.fixture
+def environment():
+    return Environment()
+
+
+@pytest.fixture
+def redis_queue():
+    return Queue(is_async=False, connection=FakeStrictRedis())
+
+
+@pytest.fixture
+def example_context(request):
+    ctx = {}
+    chosen = request.node.get_closest_marker("example_dir").args[0]
+    path_prefix = f"./tests/examples/{chosen}"
+    with open(f"{path_prefix}/input/request.json", "r") as file:
+        ctx["request"] = json.load(file)
+    with open(f"{path_prefix}/output/tds_simulation.json", "r") as file:
+        ctx["tds_simulation"] = json.load(file)
+
+    def fetch(handle, return_path=False):
+        io_dir = (
+            "input" if os.path.exists(f"{path_prefix}/input/{handle}") else "output"
+        )
+        path = f"{path_prefix}/{io_dir}/{handle}"
+        if return_path:
+            return os.path.abspath(path)
+        with open(path, "r") as file:
+            return file.read()
+
+    ctx["fetch"] = fetch
+    return ctx

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,8 @@
 from urllib.parse import urlparse, parse_qs
 import re
+import json
+import csv
+import io
 import pytest
 
 from rq import SimpleWorker, Queue
@@ -10,25 +13,19 @@ from service.api import app, get_redis
 
 
 @pytest.fixture
-def redis(environment):
-    if not environment.LIVE_REDIS:
-        return FakeStrictRedis()
-    else:
-        return None
+def redis():
+    return FakeStrictRedis()
 
 
 @pytest.fixture
 def worker(redis):
-    if redis is not None:
-        queue = Queue(connection=redis, default_timeout=-1)
-        return SimpleWorker([queue], connection=redis)
-    return None
+    queue = Queue(connection=redis, default_timeout=-1)
+    return SimpleWorker([queue], connection=redis)
 
 
 @pytest.fixture
 def client(redis):
-    if redis is not None:
-        app.dependency_overrides[get_redis] = lambda: redis
+    app.dependency_overrides[get_redis] = lambda: redis
     yield TestClient(app)
     app.dependency_overrides[get_redis] = get_redis
 
@@ -46,7 +43,7 @@ def file_storage(requests_mock):
 
     def save(request, context):
         filename = get_filename(request.url)
-        storage[filename] = request.body.read()
+        storage[filename] = request.body.read().decode("utf-8")
         return {"status": "success"}
 
     def retrieve(filename):
@@ -58,3 +55,33 @@ def file_storage(requests_mock):
     requests_mock.put(upload_url, json=save)
 
     yield retrieve
+
+
+# NOTE: This probably doesn't need to be a fixture
+@pytest.fixture
+def file_check():
+    def checker(file_type, content):
+        match file_type:
+            case "json":
+                try:
+                    json.loads(content)
+                except json.JSONDecodeError:
+                    return False
+                else:
+                    return True
+            case "csv":
+                result_csv = csv.reader(io.StringIO(content))
+                try:
+                    i = 0
+                    for _ in result_csv:
+                        i += 1
+                        if i > 10:
+                            return True
+                    return True
+                except csv.Error:
+                    return False
+            case _:
+                raise NotImplementedError("File type cannot be checked")
+        raise Exception("THIS IS BEYOND MY BRAIN")
+
+    return checker

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from rq import SimpleWorker, Queue
 from fastapi.testclient import TestClient
 from fakeredis import FakeStrictRedis
 
-from service.api import app, get_redis, enable_progress
+from service.api import app, get_redis
 
 
 @pytest.fixture
@@ -26,10 +26,8 @@ def worker(redis):
 @pytest.fixture
 def client(redis):
     app.dependency_overrides[get_redis] = lambda: redis
-    app.dependency_overrides[enable_progress] = lambda: False
     yield TestClient(app)
     app.dependency_overrides[get_redis] = get_redis
-    app.dependency_overrides[enable_progress] = enable_progress
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,36 @@
+from mock import patch
+from uuid import UUID
+import pytest
+
+from fastapi.testclient import TestClient
+from fakeredis import FakeStrictRedis
+
+from service.api import app
+
+
+@pytest.fixture
+def redis(environment, autouse=True):
+    if environment.MOCK_REDIS:
+        with patch("service.utils.get_redis", return_value=FakeStrictRedis()):
+            yield
+    else:
+        yield
+
+
+@pytest.fixture
+def patch_uuid(request, autouse=True):
+    if "example_context" in request.fixturenames:
+        context = request.getfixturevalue("example_context")
+        job_id = context["tds_simulation"]["id"]
+        with patch(
+            "uuid.uuid4",
+            return_value=UUID(job_id.strip("ciemss-")),
+        ):
+            yield
+    else:
+        yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,8 +45,8 @@ def file_storage():
         return {"url": f"filesave?filename={filename}"}
 
     def save(request, context):
-        filename = get_filename(request.url)
-        storage[filename] = context
+        # filename = get_filename(request.url)
+        # storage[filename] = context
         return {"status": "success"}
 
     def retrieve(filename):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -42,11 +42,11 @@ def file_storage():
 
     def get_loc(request, _):
         filename = get_filename(request.url)
-        return {"url": f"filesave?filename={filename}"}
+        return {"url": f"https://filesave?filename={filename}"}
 
     def save(request, context):
-        # filename = get_filename(request.url)
-        # storage[filename] = context
+        filename = get_filename(request.url)
+        storage[filename] = request.body.read()
         return {"status": "success"}
 
     def retrieve(filename):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from rq import SimpleWorker, Queue
 from fastapi.testclient import TestClient
 from fakeredis import FakeStrictRedis
 
-from service.api import app, get_redis
+from service.api import app, get_redis, enable_progress
 
 
 @pytest.fixture
@@ -26,8 +26,10 @@ def worker(redis):
 @pytest.fixture
 def client(redis):
     app.dependency_overrides[get_redis] = lambda: redis
+    app.dependency_overrides[enable_progress] = lambda: False
     yield TestClient(app)
     app.dependency_overrides[get_redis] = get_redis
+    app.dependency_overrides[enable_progress] = enable_progress
 
 
 @pytest.fixture
@@ -82,6 +84,5 @@ def file_check():
                     return False
             case _:
                 raise NotImplementedError("File type cannot be checked")
-        raise Exception("THIS IS BEYOND MY BRAIN")
 
     return checker

--- a/tests/integration/simulate.py
+++ b/tests/integration/simulate.py
@@ -1,0 +1,5 @@
+# from mock import patch
+# import pytest
+
+
+# dwf test_simulate_example(client, redis_queue, request_mock)

--- a/tests/integration/simulate.py
+++ b/tests/integration/simulate.py
@@ -1,5 +1,0 @@
-# from mock import patch
-# import pytest
-
-
-# dwf test_simulate_example(client, redis_queue, request_mock)

--- a/tests/integration/test_calibrate.py
+++ b/tests/integration/test_calibrate.py
@@ -1,0 +1,67 @@
+import json
+
+import pytest
+
+from service.settings import settings
+
+TDS_URL = settings.TDS_URL
+
+
+@pytest.mark.example_dir("calibrate")
+def test_calibrate_example(
+    example_context, client, worker, file_storage, file_check, requests_mock
+):
+    request = example_context["request"]
+    config_id = request["model_config_id"]
+    model = json.loads(example_context["fetch"](config_id + ".json"))
+
+    dataset_id = example_context["request"]["dataset"]["id"]
+    filename = example_context["request"]["dataset"]["filename"]
+    dataset = example_context["fetch"](filename, True)
+    dataset_loc = {"method": "GET", "url": dataset}
+    requests_mock.get(
+        f"{TDS_URL}/datasets/{dataset_id}/download-url?filename={filename}",
+        json=dataset_loc,
+    )
+
+    requests_mock.post(f"{TDS_URL}/simulations/", json={"id": None})
+
+    response = client.post(
+        "/calibrate",
+        json=request,
+        headers={"Content-Type": "application/json"},
+    )
+    simulation_id = response.json()["simulation_id"]
+    response = client.get(
+        f"/status/{simulation_id}",
+    )
+    status = response.json()["status"]
+    assert status == "queued"
+
+    tds_sim = example_context["tds_simulation"]
+    tds_sim["id"] = simulation_id
+
+    requests_mock.get(f"{TDS_URL}/simulations/{simulation_id}", json=tds_sim)
+    requests_mock.put(
+        f"{TDS_URL}/simulations/{simulation_id}", json={"status": "success"}
+    )
+    requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
+
+    worker.work(burst=True)
+
+    response = client.get(
+        f"/status/{simulation_id}",
+    )
+    status = response.json()["status"]
+    result = file_storage("result.csv")
+    viz = file_storage("visualization.json")
+    # eval = file_storage("eval.csv") # NOTE: Do we want to check this
+
+    # Checks
+    assert status == "complete"
+
+    assert result is not None
+    assert file_check("csv", result)
+
+    assert viz is not None
+    assert file_check("json", viz)

--- a/tests/integration/test_ensemble_calibrate.py
+++ b/tests/integration/test_ensemble_calibrate.py
@@ -1,0 +1,71 @@
+import json
+
+import pytest
+
+from service.settings import settings
+
+TDS_URL = settings.TDS_URL
+
+
+@pytest.mark.example_dir("ensemble-calibrate")
+def test_ensemble_calibrate_example(
+    example_context, client, worker, file_storage, file_check, requests_mock
+):
+    request = example_context["request"]
+    config_ids = [
+        config["id"] for config in example_context["request"]["model_configs"]
+    ]
+    for config_id in config_ids:
+        model = json.loads(example_context["fetch"](config_id + ".json"))
+        requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
+
+    dataset_id = example_context["request"]["dataset"]["id"]
+    filename = example_context["request"]["dataset"]["filename"]
+    dataset = example_context["fetch"](filename, True)
+    dataset_loc = {"method": "GET", "url": dataset}
+    requests_mock.get(
+        f"{TDS_URL}/datasets/{dataset_id}/download-url?filename={filename}",
+        json=dataset_loc,
+    )
+    requests_mock.get("http://dataset", text=dataset)
+
+    requests_mock.post(f"{TDS_URL}/simulations/", json={"id": None})
+
+    response = client.post(
+        "/ensemble-calibrate",
+        json=request,
+        headers={"Content-Type": "application/json"},
+    )
+    simulation_id = response.json()["simulation_id"]
+    response = client.get(
+        f"/status/{simulation_id}",
+    )
+    status = response.json()["status"]
+    assert status == "queued"
+
+    tds_sim = example_context["tds_simulation"]
+    tds_sim["id"] = simulation_id
+
+    requests_mock.get(f"{TDS_URL}/simulations/{simulation_id}", json=tds_sim)
+    requests_mock.put(
+        f"{TDS_URL}/simulations/{simulation_id}", json={"status": "success"}
+    )
+
+    worker.work(burst=True)
+
+    response = client.get(
+        f"/status/{simulation_id}",
+    )
+    status = response.json()["status"]
+    result = file_storage("result.csv")
+    viz = file_storage("visualization.json")
+    # eval = file_storage("eval.csv") # NOTE: Do we want to check this
+
+    # Checks
+    assert status == "complete"
+
+    assert result is not None
+    assert file_check("csv", result)
+
+    assert viz is not None
+    assert file_check("json", viz)

--- a/tests/integration/test_ensemble_simulate.py
+++ b/tests/integration/test_ensemble_simulate.py
@@ -1,0 +1,61 @@
+import json
+
+import pytest
+
+from service.settings import settings
+
+TDS_URL = settings.TDS_URL
+
+
+@pytest.mark.example_dir("ensemble-simulate")
+def test_ensemble_simulate_example(
+    example_context, client, worker, file_storage, file_check, requests_mock
+):
+    request = example_context["request"]
+    config_ids = [
+        config["id"] for config in example_context["request"]["model_configs"]
+    ]
+    for config_id in config_ids:
+        model = json.loads(example_context["fetch"](config_id + ".json"))
+        requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
+
+    requests_mock.post(f"{TDS_URL}/simulations/", json={"id": None})
+
+    response = client.post(
+        "/ensemble-simulate",
+        json=request,
+        headers={"Content-Type": "application/json"},
+    )
+    simulation_id = response.json()["simulation_id"]
+    response = client.get(
+        f"/status/{simulation_id}",
+    )
+    status = response.json()["status"]
+    assert status == "queued"
+
+    tds_sim = example_context["tds_simulation"]
+    tds_sim["id"] = simulation_id
+
+    requests_mock.get(f"{TDS_URL}/simulations/{simulation_id}", json=tds_sim)
+    requests_mock.put(
+        f"{TDS_URL}/simulations/{simulation_id}", json={"status": "success"}
+    )
+
+    worker.work(burst=True)
+
+    response = client.get(
+        f"/status/{simulation_id}",
+    )
+    status = response.json()["status"]
+    result = file_storage("result.csv")
+    viz = file_storage("visualization.json")
+    # eval = file_storage("eval.csv") # NOTE: Do we want to check this
+
+    # Checks
+    assert status == "complete"
+
+    assert result is not None
+    assert file_check("csv", result)
+
+    assert viz is not None
+    assert file_check("json", viz)

--- a/tests/integration/test_simulate.py
+++ b/tests/integration/test_simulate.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 import pytest
 
@@ -36,11 +35,6 @@ def test_simulate_example(example_context, client, worker, file_storage, request
         f"{TDS_URL}/simulations/{simulation_id}", json={"status": "success"}
     )
     requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
-    # TODO: Save files to locations where we can check against them
-    get_upload_url = re.compile("upload-url")
-    requests_mock.get(get_upload_url, json=file_storage.get_loc)
-    upload_url = re.compile("filesave")
-    requests_mock.put(upload_url, json=file_storage.save)
 
     # TODO: Mock PyCIEMSS lib
     worker.work(burst=True)

--- a/tests/integration/test_simulate.py
+++ b/tests/integration/test_simulate.py
@@ -9,7 +9,7 @@ TDS_URL = settings.TDS_URL
 
 
 @pytest.mark.example_dir("simulate")
-def test_simulate_example(example_context, client, worker, requests_mock):
+def test_simulate_example(example_context, client, worker, file_storage, requests_mock):
     request = example_context["request"]
     config_id = request["model_config_id"]
     model = json.loads(example_context["fetch"](config_id + ".json"))
@@ -38,7 +38,7 @@ def test_simulate_example(example_context, client, worker, requests_mock):
     requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
     # TODO: Save files to locations where we can check against them
     upload_url = re.compile("upload-url")
-    requests_mock.get(upload_url, json={"url": "http://WONTWORK"})
+    requests_mock.get(upload_url, json=file_storage.get_loc)
     requests_mock.put("http://WONTWORK", json={"url": "WONTWORK"})
 
     # TODO: Mock PyCIEMSS lib

--- a/tests/integration/test_simulate.py
+++ b/tests/integration/test_simulate.py
@@ -37,9 +37,10 @@ def test_simulate_example(example_context, client, worker, file_storage, request
     )
     requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
     # TODO: Save files to locations where we can check against them
-    upload_url = re.compile("upload-url")
-    requests_mock.get(upload_url, json=file_storage.get_loc)
-    requests_mock.put("http://WONTWORK", json={"url": "WONTWORK"})
+    get_upload_url = re.compile("upload-url")
+    requests_mock.get(get_upload_url, json=file_storage.get_loc)
+    upload_url = re.compile("filesave")
+    requests_mock.put(upload_url, json=file_storage.save)
 
     # TODO: Mock PyCIEMSS lib
     worker.work(burst=True)

--- a/tests/integration/test_simulate.py
+++ b/tests/integration/test_simulate.py
@@ -1,0 +1,26 @@
+# import json
+
+import pytest
+
+from service.settings import settings
+
+TDS_URL = settings.TDS_URL
+
+
+@pytest.mark.example_dir("simulate")
+def test_simulate_example(example_context, client, requests_mock):
+    job_id = example_context["tds_simulation"]["id"]
+    request = example_context["request"]
+    # config_id = request["model_config_id"]
+    # model = json.loads(example_context["fetch"](config_id + ".json"))
+
+    requests_mock.post(f"{TDS_URL}/simulations/", json={"id": None})
+
+    full_response = client.post(
+        "/simulate",
+        json=request,
+        headers={"Content-Type": "application/json"},
+    )
+    response = full_response.json()
+
+    assert response["simulation_id"] == job_id

--- a/tests/integration/test_simulate.py
+++ b/tests/integration/test_simulate.py
@@ -1,4 +1,5 @@
-# import json
+import json
+import re
 
 import pytest
 
@@ -9,10 +10,9 @@ TDS_URL = settings.TDS_URL
 
 @pytest.mark.example_dir("simulate")
 def test_simulate_example(example_context, client, worker, requests_mock):
-    # job_id = example_context["tds_simulation"]["id"]
     request = example_context["request"]
-    # config_id = request["model_config_id"]
-    # model = json.loads(example_context["fetch"](config_id + ".json"))
+    config_id = request["model_config_id"]
+    model = json.loads(example_context["fetch"](config_id + ".json"))
 
     requests_mock.post(f"{TDS_URL}/simulations/", json={"id": None})
 
@@ -28,4 +28,24 @@ def test_simulate_example(example_context, client, worker, requests_mock):
     status = response.json()["status"]
     assert status == "queued"
 
+    tds_sim = example_context["tds_simulation"]
+    tds_sim["id"] = simulation_id
+
+    requests_mock.get(f"{TDS_URL}/simulations/{simulation_id}", json=tds_sim)
+    requests_mock.put(
+        f"{TDS_URL}/simulations/{simulation_id}", json={"status": "success"}
+    )
+    requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
+    # TODO: Save files to locations where we can check against them
+    upload_url = re.compile("upload-url")
+    requests_mock.get(upload_url, json={"url": "http://WONTWORK"})
+    requests_mock.put("http://WONTWORK", json={"url": "WONTWORK"})
+
+    # TODO: Mock PyCIEMSS lib
     worker.work(burst=True)
+
+    response = client.get(
+        f"/status/{simulation_id}",
+    )
+    status = response.json()["status"]
+    assert status == "complete"

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,5 +1,4 @@
 import json
-import os
 from inspect import signature
 
 from mock import patch
@@ -36,42 +35,18 @@ def is_satisfactory(kwargs, f):
     return True
 
 
-@pytest.fixture
-def operation_context(request):
-    ctx = {}
-    chosen = request.node.get_closest_marker("operation").args[0]
-    path_prefix = f"./tests/examples/{chosen}"
-    with open(f"{path_prefix}/input/request.json", "r") as file:
-        ctx["request"] = json.load(file)
-    with open(f"{path_prefix}/output/tds_simulation.json", "r") as file:
-        ctx["tds_simulation"] = json.load(file)
-
-    def fetch(handle, return_path=False):
-        io_dir = (
-            "input" if os.path.exists(f"{path_prefix}/input/{handle}") else "output"
-        )
-        path = f"{path_prefix}/{io_dir}/{handle}"
-        if return_path:
-            return os.path.abspath(path)
-        with open(path, "r") as file:
-            return file.read()
-
-    ctx["fetch"] = fetch
-    return ctx
-
-
 class TestSimulate:
-    @pytest.mark.operation("simulate")
-    def test_example_conversion(self, operation_context, requests_mock):
-        job_id = operation_context["tds_simulation"]["id"]
+    @pytest.mark.example_dir("simulate")
+    def test_example_conversion(self, example_context, requests_mock):
+        job_id = example_context["tds_simulation"]["id"]
 
-        config_id = operation_context["request"]["model_config_id"]
-        model = json.loads(operation_context["fetch"](config_id + ".json"))
+        config_id = example_context["request"]["model_config_id"]
+        model = json.loads(example_context["fetch"](config_id + ".json"))
         requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
 
         ### Act and Assert
 
-        operation_request = Simulate(**operation_context["request"])
+        operation_request = Simulate(**example_context["request"])
         kwargs = operation_request.gen_pyciemss_args(job_id)
 
         assert kwargs.get("visual_options", False)
@@ -79,17 +54,17 @@ class TestSimulate:
 
 
 class TestCalibrate:
-    @pytest.mark.operation("calibrate")
-    def test_example_conversion(self, operation_context, requests_mock):
-        job_id = operation_context["tds_simulation"]["id"]
+    @pytest.mark.example_dir("calibrate")
+    def test_example_conversion(self, example_context, requests_mock):
+        job_id = example_context["tds_simulation"]["id"]
 
-        config_id = operation_context["request"]["model_config_id"]
-        model = json.loads(operation_context["fetch"](config_id + ".json"))
+        config_id = example_context["request"]["model_config_id"]
+        model = json.loads(example_context["fetch"](config_id + ".json"))
         requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
 
-        dataset_id = operation_context["request"]["dataset"]["id"]
-        filename = operation_context["request"]["dataset"]["filename"]
-        dataset = operation_context["fetch"](filename, True)
+        dataset_id = example_context["request"]["dataset"]["id"]
+        filename = example_context["request"]["dataset"]["filename"]
+        dataset = example_context["fetch"](filename, True)
         dataset_loc = {"method": "GET", "url": dataset}
         requests_mock.get(
             f"{TDS_URL}/datasets/{dataset_id}/download-url?filename={filename}",
@@ -99,7 +74,7 @@ class TestCalibrate:
         ### Act and Assert
 
         with patch("service.models.gen_rabbitmq_hook", return_value=lambda _: None):
-            operation_request = Calibrate(**operation_context["request"])
+            operation_request = Calibrate(**example_context["request"])
             kwargs = operation_request.gen_pyciemss_args(job_id)
 
         assert kwargs.get("visual_options", False)
@@ -107,20 +82,20 @@ class TestCalibrate:
 
 
 class TestEnsembleSimulate:
-    @pytest.mark.operation("ensemble-simulate")
-    def test_example_conversion(self, operation_context, requests_mock):
-        job_id = operation_context["tds_simulation"]["id"]
+    @pytest.mark.example_dir("ensemble-simulate")
+    def test_example_conversion(self, example_context, requests_mock):
+        job_id = example_context["tds_simulation"]["id"]
 
         config_ids = [
-            config["id"] for config in operation_context["request"]["model_configs"]
+            config["id"] for config in example_context["request"]["model_configs"]
         ]
         for config_id in config_ids:
-            model = json.loads(operation_context["fetch"](config_id + ".json"))
+            model = json.loads(example_context["fetch"](config_id + ".json"))
             requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
 
         ### Act and Assert
 
-        operation_request = EnsembleSimulate(**operation_context["request"])
+        operation_request = EnsembleSimulate(**example_context["request"])
         kwargs = operation_request.gen_pyciemss_args(job_id)
 
         assert kwargs.get("visual_options", False)
@@ -128,20 +103,20 @@ class TestEnsembleSimulate:
 
 
 class TestEnsembleCalibrate:
-    @pytest.mark.operation("ensemble-calibrate")
-    def test_example_conversion(self, operation_context, requests_mock):
-        job_id = operation_context["tds_simulation"]["id"]
+    @pytest.mark.example_dir("ensemble-calibrate")
+    def test_example_conversion(self, example_context, requests_mock):
+        job_id = example_context["tds_simulation"]["id"]
 
         config_ids = [
-            config["id"] for config in operation_context["request"]["model_configs"]
+            config["id"] for config in example_context["request"]["model_configs"]
         ]
         for config_id in config_ids:
-            model = json.loads(operation_context["fetch"](config_id + ".json"))
+            model = json.loads(example_context["fetch"](config_id + ".json"))
             requests_mock.get(f"{TDS_URL}/model_configurations/{config_id}", json=model)
 
-        dataset_id = operation_context["request"]["dataset"]["id"]
-        filename = operation_context["request"]["dataset"]["filename"]
-        dataset = operation_context["fetch"](filename, True)
+        dataset_id = example_context["request"]["dataset"]["id"]
+        filename = example_context["request"]["dataset"]["filename"]
+        dataset = example_context["fetch"](filename, True)
         dataset_loc = {"method": "GET", "url": dataset}
         requests_mock.get(
             f"{TDS_URL}/datasets/{dataset_id}/download-url?filename={filename}",
@@ -151,7 +126,7 @@ class TestEnsembleCalibrate:
 
         ### Act and Assert
 
-        operation_request = EnsembleCalibrate(**operation_context["request"])
+        operation_request = EnsembleCalibrate(**example_context["request"])
         kwargs = operation_request.gen_pyciemss_args(job_id)
 
         assert kwargs.get("visual_options", False)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,7 +1,6 @@
 import json
 from inspect import signature
 
-from mock import patch
 import pytest
 
 from pyciemss.PetriNetODE.interfaces import (  # noqa: F401
@@ -72,10 +71,8 @@ class TestCalibrate:
         )
 
         ### Act and Assert
-
-        with patch("service.models.gen_rabbitmq_hook", return_value=lambda _: None):
-            operation_request = Calibrate(**example_context["request"])
-            kwargs = operation_request.gen_pyciemss_args(job_id)
+        operation_request = Calibrate(**example_context["request"])
+        kwargs = operation_request.gen_pyciemss_args(job_id)
 
         assert kwargs.get("visual_options", False)
         assert is_satisfactory(kwargs, load_and_calibrate_and_sample_petri_model)


### PR DESCRIPTION
This PR runs through the whole flow for a given example. We use FakeRedis and the FastAPI testclient so we can actually run the flow without fully mocking everything. We can give RQ a connection to FakeRedis, enabling us to execute RQ within our tests.

We run the PyCIEMSS library live which has been helpful for debugging but it is a bit slow.

This PR does NOT test RabbitMQ or validate the requests being sent to TDS. These can be added in future tests. Furthermore, the faking mentioned above opens us up for more unit tests of the individual components

## Other changes
- Redis is now a FastAPI dependency
- RabbitMQ warns instead of failing the entire operation