### PR TITLE
fix: allow calibrate jobs to run when all dataset variables arent mapped

### DIFF
--- a/service/utils/tds.py
+++ b/service/utils/tds.py
@@ -90,7 +90,7 @@ def fetch_dataset(dataset: dict, tds_api, job_id):
     df = pd.read_csv(response.json()["url"])
     df = df.rename(columns=dataset["mappings"])
     # drop columns that aren't being mapped
-    if len(df.columns) > len(dataset["mappings"]):
+    if len(df.columns) > len(dataset["mappings"]) and len(dataset["mappings"]) > 0:
         extra_columns = set(df.columns) - set(dataset["mappings"].values())
         df.drop(columns=list(extra_columns), inplace=True)
     dataset_path = os.path.join(job_dir, "./temp.json")

--- a/service/utils/tds.py
+++ b/service/utils/tds.py
@@ -89,6 +89,10 @@ def fetch_dataset(dataset: dict, tds_api, job_id):
         raise HTTPException(status_code=400, detail="Unable to retrieve dataset")
     df = pd.read_csv(response.json()["url"])
     df = df.rename(columns=dataset["mappings"])
+    # drop columns that aren't being mapped
+    if len(df.columns) > len(dataset["mappings"]):
+        extra_columns = set(df.columns) - set(dataset["mappings"].values())
+        df.drop(columns=list(extra_columns), inplace=True)
     dataset_path = os.path.join(job_dir, "./temp.json")
     with open(dataset_path, "w") as file:
         df.to_csv(file, index=False)


### PR DESCRIPTION
# Description

* Small fix to allow the calibrate job to run when only a partial dataset is mapped (i.e. If a dataset has columns SIRC and a user only maps SIR this should be allowed)
* columns that aren't mapped are dropped
Resolves #(issue)
https://github.com/DARPA-ASKEM/Terarium/issues/1660