### PR TITLE
scoping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ httpx = "^0.24.1"
 
 
 [tool.poe.tasks]
-install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@1fabf279590c613a8ed38d88c6b6faf0c52ba867 --use-pep517"
+install-pyciemss = "pip install --no-cache-dir pyro-ppl==1.8.6 git+https://github.com/ciemss/pyciemss.git@1fabf279590c613a8ed38d88c6b6faf0c52ba867 --use-pep517"
 
 
 [tool.pytest.ini_options]

--- a/service/api.py
+++ b/service/api.py
@@ -100,12 +100,16 @@ def cancel_job(
 for operation_name, schema in operations.items():
     registrar = app.post(f"/{operation_name}", response_model=JobResponse)
 
-    def operate(
-        body: schema,
-        redis_conn=Depends(get_redis),
-    ) -> JobResponse:
-        return create_job(body, operation_name, redis_conn)
+    def make_operate(operation):
+        def operate(
+            body: schema,
+            redis_conn=Depends(get_redis),
+        ) -> JobResponse:
+            return create_job(body, operation, redis_conn)
 
+        return operate
+
+    operate = make_operate(operation_name)
     registrar(operate)
 
 


### PR DESCRIPTION
### Summary
Address a scoping issue in building out fast-api routes, this was mislabelling operation's type field with the last operation type in the listing.