### PR TITLE
Expose errors with status endpoint

### DIFF
--- a/service/api.py
+++ b/service/api.py
@@ -74,12 +74,15 @@ def get_status(
     """
     Retrieve the status of a simulation
     """
-    status = fetch_job_status(simulation_id, redis_conn)
+    status, error_msg = fetch_job_status(simulation_id, redis_conn)
     logging.info(status)
     if not isinstance(status, str):
         return status
 
-    return {"status": Status.from_rq(status)}
+    return {
+        "status": Status.from_rq(status),
+        "error_msg": error_msg,
+    }
 
 
 @app.get(

--- a/service/models/response.py
+++ b/service/models/response.py
@@ -41,3 +41,4 @@ class JobResponse(BaseModel):
 
 class StatusSimulationIdGetResponse(BaseModel):
     status: Optional[Status] = None
+    error_msg: Optional[str] = None

--- a/service/utils/rq_helpers.py
+++ b/service/utils/rq_helpers.py
@@ -79,15 +79,17 @@ def fetch_job_status(job_id, redis_conn):
     """
     try:
         job = Job.fetch(job_id, connection=redis_conn)
-        # r = job.latest_result()
-        # string_res = r.return_value
-        result = job.get_status()
-        return result
     except NoSuchJobError:
-        return Response(
-            status_code=status.HTTP_404_NOT_FOUND,
-            content=f"Simulation {job_id} not found",
+        return (
+            Response(
+                status_code=status.HTTP_404_NOT_FOUND,
+                content=f"Simulation {job_id} not found",
+            ),
+            None,
         )
+    else:
+        result = job.get_status()
+        return result, job.exc_info
 
 
 def kill_job(job_id, redis_conn):


### PR DESCRIPTION
The status endpoint is updated to include possible exception message that is generated at runtime within the RQ worker