### PR TITLE
Select from two QOI options

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707956935,
+        "narHash": "sha256-ZL2TrjVsiFNKOYwYQozpbvQSwvtV/3Me7Zwhmdsfyu4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a4d4fe8c5002202493e87ec8dbc91335ff55552c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "PyCIEMSS Dev FHS Environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+    in
+      flake-utils.lib.eachDefaultSystem (
+        system:
+          let
+            pkgs = import nixpkgs { inherit system; };
+          in rec {
+              packages = { };
+              devShell  = pkgs.mkShell {
+                name = "python-fhs-env";
+                buildInputs = [
+                  pkgs.pkg-config
+                  pkgs.python3Packages.cython
+
+                  pkgs.xorg.libX11
+                  pkgs.stdenv.cc.cc.lib
+                  pkgs.zlib
+                  pkgs.libzip
+                  pkgs.libGL
+                  # pkgs.opencl-headers
+                  pkgs.ocl-icd
+                  pkgs.openssl
+                  pkgs.mtdev
+                  pkgs.mesa
+                  pkgs.autoPatchelfHook
+
+                  pkgs.firefox
+
+                  pkgs.python3
+                  pkgs.poetry
+                  pkgs.python3Packages.venvShellHook
+                ];
+                # propagatedBuildInputs = [
+                # ];
+                packages = [
+                ];
+
+                venvDir = "./.venv";
+                postVenvCreation = ''
+                  unset SOURCE_DATE_EPOCH
+                  autoPatchelf ./.venv
+                '';
+                postShellHook = ''
+                  unset SOURCE_DATE_EPOCH
+                  export LD_LIBRARY_PATH=${pkgs.openssl.out}/lib:${pkgs.libzip}/lib:${pkgs.ocl-icd}/lib:${pkgs.libGL}/lib:${pkgs.mtdev}/lib:${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH
+                '';
+                preferLocalBuild = true;
+              };
+            }
+      );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ httpx = "^0.24.1"
 
 
 [tool.poe.tasks]
-install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@a7da30fc9dfd58251b07a87cb7a318a4e1a605a5 --use-pep517"
+install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@8283eca66f38ef448c55b3bfede860b772b92dbb --use-pep517"
 
 
 [tool.pytest.ini_options]

--- a/tests/examples/optimize/input/request.json
+++ b/tests/examples/optimize/input/request.json
@@ -12,7 +12,10 @@
 		"start": 0,
 		"end": 90
 	},
-	"qoi": ["Infected"],
+	"qoi": {
+		"contexts": ["Infected"],
+		"method": "day_average"
+	},
 	"risk_bound": 10.0,
   	"initial_guess_interventions": [1.0],
   	"bounds_interventions": [[0.0], [3.0]],


### PR DESCRIPTION
The `qoi` field for the `/optimize` endpoint now takes a QOI object. The QOI option allows you to select from two `method`s ('day_average' and 'max') and a list of strings `contexts` (pass to `contexts` what you used to pass to `qoi`).