### PR TITLE
Kill jobs on cancel

### DIFF
--- a/service/models/response.py
+++ b/service/models/response.py
@@ -20,10 +20,12 @@ class Status(Enum):
     def from_rq(rq_status):
         rq_status_to_tds_status = {
             "canceled": "cancelled",
+            "stopped": "cancelled",
             "complete": "complete",
             "error": "error",
             "queued": "queued",
             "running": "running",
+            "working": "running",
             "failed": "failed",
             "started": "running",
             "finished": "complete",

--- a/service/utils/rq_helpers.py
+++ b/service/utils/rq_helpers.py
@@ -9,6 +9,7 @@ from redis import Redis
 from rq import Queue
 from rq.exceptions import NoSuchJobError
 from rq.job import Job
+from rq.command import send_stop_job_command
 
 from settings import settings
 from utils.tds import update_tds_status, create_tds_job, cancel_tds_job
@@ -102,6 +103,7 @@ def kill_job(job_id, redis_conn):
         )
     else:
         job.cancel()
+        send_stop_job_command(redis_conn, job_id)
 
         cancel_tds_job(str(job_id))
 


### PR DESCRIPTION
`/cancel` kills the job instead of just removing it from the queue.