### PR TITLE
observable sanity check

### DIFF
--- a/service/utils/tds.py
+++ b/service/utils/tds.py
@@ -114,7 +114,15 @@ def fetch_model(model_config_id, job_id):
 
     amr_path = os.path.join(job_dir, f"./{model_config_id}.json")
     with open(amr_path, "w") as file:
-        json.dump(model_response.json()["configuration"], file)
+        # Ensure we don't have null observables which can be problematic downstream, if so convert
+        # to empty list
+        model_json = model_response.json()["configuration"]
+        if "semantics" in model_json and "ode" in model_json["semantics"]:
+            ode = model_json["semantics"]["ode"]
+            if "observables" in ode and ode["observables"] is None:
+                ode["observables"] = []
+
+        json.dump(model_json, file)
     return amr_path
 
 


### PR DESCRIPTION
### Summary
In the weird cases where `observables == null`, it creates minor issues downstream MIRA that is called by pyciemss. This force convert null-cases into empty list which is acceptable by MIRA.

Note MIRA is aware of this and Ben G. he can make a fix on his end, so this is extra security until then.