### PR TITLE
Pointing to the legacy endpoint for model configs for now.

### DIFF
--- a/service/utils/tds.py
+++ b/service/utils/tds.py
@@ -22,7 +22,7 @@ TDS_USER = settings.TDS_USER
 TDS_PASSWORD = settings.TDS_PASSWORD
 TDS_SIMULATIONS = "/simulations"
 TDS_DATASETS = "/datasets"
-TDS_CONFIGURATIONS = "/model-configurations"
+TDS_CONFIGURATIONS = "/model-configurations-legacy"
 
 
 def tds_session():

--- a/tests/integration/test_calibrate.py
+++ b/tests/integration/test_calibrate.py
@@ -47,7 +47,7 @@ def test_calibrate_example(
     requests_mock.put(
         f"{TDS_URL}/simulations/{simulation_id}", json={"status": "success"}
     )
-    requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+    requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
     worker.work(burst=True)
 

--- a/tests/integration/test_ensemble_calibrate.py
+++ b/tests/integration/test_ensemble_calibrate.py
@@ -19,7 +19,9 @@ def test_ensemble_calibrate_example(
     ]
     for config_id in config_ids:
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
+        requests_mock.get(
+            f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model
+        )
 
     dataset_id = example_context["request"]["dataset"]["id"]
     filename = example_context["request"]["dataset"]["filename"]

--- a/tests/integration/test_ensemble_calibrate.py
+++ b/tests/integration/test_ensemble_calibrate.py
@@ -19,7 +19,7 @@ def test_ensemble_calibrate_example(
     ]
     for config_id in config_ids:
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
     dataset_id = example_context["request"]["dataset"]["id"]
     filename = example_context["request"]["dataset"]["filename"]

--- a/tests/integration/test_ensemble_simulate.py
+++ b/tests/integration/test_ensemble_simulate.py
@@ -19,7 +19,7 @@ def test_ensemble_simulate_example(
     ]
     for config_id in config_ids:
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
     requests_mock.post(f"{TDS_URL}/simulations", json={"id": str(job_id)})
 

--- a/tests/integration/test_ensemble_simulate.py
+++ b/tests/integration/test_ensemble_simulate.py
@@ -19,7 +19,9 @@ def test_ensemble_simulate_example(
     ]
     for config_id in config_ids:
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
+        requests_mock.get(
+            f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model
+        )
 
     requests_mock.post(f"{TDS_URL}/simulations", json={"id": str(job_id)})
 

--- a/tests/integration/test_optimize.py
+++ b/tests/integration/test_optimize.py
@@ -37,7 +37,7 @@ def test_optimize_example(
     requests_mock.put(
         f"{TDS_URL}/simulations/{simulation_id}", json={"status": "success"}
     )
-    requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+    requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
     worker.work(burst=True)
 

--- a/tests/integration/test_simulate.py
+++ b/tests/integration/test_simulate.py
@@ -38,7 +38,7 @@ def test_simulate_example(
     requests_mock.put(
         f"{TDS_URL}/simulations/{simulation_id}", json={"status": "success"}
     )
-    requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+    requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
     worker.work(burst=True)
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -42,7 +42,7 @@ class TestSimulate:
 
         config_id = example_context["request"]["model_config_id"]
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
         ### Act and Assert
 
@@ -60,7 +60,7 @@ class TestCalibrate:
 
         config_id = example_context["request"]["model_config_id"]
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
         dataset_id = example_context["request"]["dataset"]["id"]
         filename = example_context["request"]["dataset"]["filename"]
@@ -89,7 +89,7 @@ class TestEnsembleSimulate:
         ]
         for config_id in config_ids:
             model = json.loads(example_context["fetch"](config_id + ".json"))
-            requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+            requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
         ### Act and Assert
 
@@ -110,7 +110,7 @@ class TestEnsembleCalibrate:
         ]
         for config_id in config_ids:
             model = json.loads(example_context["fetch"](config_id + ".json"))
-            requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+            requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
         dataset_id = example_context["request"]["dataset"]["id"]
         filename = example_context["request"]["dataset"]["filename"]
@@ -137,7 +137,7 @@ class TestOptimize:
 
         config_id = example_context["request"]["model_config_id"]
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations/{config_id}", json=model)
+        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
 
         ### Act and Assert
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -42,7 +42,9 @@ class TestSimulate:
 
         config_id = example_context["request"]["model_config_id"]
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
+        requests_mock.get(
+            f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model
+        )
 
         ### Act and Assert
 
@@ -60,7 +62,9 @@ class TestCalibrate:
 
         config_id = example_context["request"]["model_config_id"]
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
+        requests_mock.get(
+            f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model
+        )
 
         dataset_id = example_context["request"]["dataset"]["id"]
         filename = example_context["request"]["dataset"]["filename"]
@@ -89,7 +93,9 @@ class TestEnsembleSimulate:
         ]
         for config_id in config_ids:
             model = json.loads(example_context["fetch"](config_id + ".json"))
-            requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
+            requests_mock.get(
+                f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model
+            )
 
         ### Act and Assert
 
@@ -110,7 +116,9 @@ class TestEnsembleCalibrate:
         ]
         for config_id in config_ids:
             model = json.loads(example_context["fetch"](config_id + ".json"))
-            requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
+            requests_mock.get(
+                f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model
+            )
 
         dataset_id = example_context["request"]["dataset"]["id"]
         filename = example_context["request"]["dataset"]["filename"]
@@ -137,7 +145,9 @@ class TestOptimize:
 
         config_id = example_context["request"]["model_config_id"]
         model = json.loads(example_context["fetch"](config_id + ".json"))
-        requests_mock.get(f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model)
+        requests_mock.get(
+            f"{TDS_URL}/model-configurations-legacy/{config_id}", json=model
+        )
 
         ### Act and Assert
 


### PR DESCRIPTION
We are currently in the midst of a major refactor on model-configurations and are changing how the endpoints will work. As this system gets integrated we've kept the old model config objects and endpoints active until we're ready to flip the switch.

Note that this PR should not be merged until HMI-Server is updated to use these endpoints correctly: https://github.com/DARPA-ASKEM/terarium/pull/3802