### PR TITLE
Add explicit dependency on pinned python NetCDF version

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -7,6 +7,9 @@ COPY poetry.lock poetry.lock
 RUN poetry config virtualenvs.create false && \
     poetry install --no-root --no-cache
 
+# Pin netCDF4 to version 1.6.5
+RUN pip install netCDF4==1.6.5
+    
 # We have to install PyCIEMSS now since the interface uses Torch
 # TODO: Do not use Torch in PyCIEMSS Library interface
 RUN poetry run poe install-pyciemss 

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -14,6 +14,9 @@ COPY poetry.lock poetry.lock
 RUN poetry config virtualenvs.create false && \
     poetry install --no-root --no-cache
 
+# Pin netCDF4 to version 1.6.5
+RUN pip install netCDF4==1.6.5
+
 RUN poetry run poe install-pyciemss
 COPY service service
 COPY tests tests


### PR DESCRIPTION
This isn't really optimal. When I specified the version in `pyproject.toml` it failed to resolve. Python NetCDF lib is wierd. Pinning it in `pyciemss` directly [here](https://github.com/ciemss/pyciemss/blob/main/setup.cfg#L10-L23) would be ideal I think. But this should fix the build.