### PR TITLE
Add result_summary.csv

### DIFF
--- a/service/utils/tds.py
+++ b/service/utils/tds.py
@@ -226,6 +226,7 @@ def get_result_summary(data_result):
                     data_result[from_index:to_index][col_name]
                 )
                 series_row.insert(0, col_name)
+                series_row.insert(0, "sample_id: " + str(i))
                 summary_result.append(series_row)
 
         return summary_result

--- a/service/utils/tds.py
+++ b/service/utils/tds.py
@@ -14,7 +14,6 @@ import numbers
 from datetime import datetime
 from typing import Optional
 import pandas as pd
-import numpy as np
 
 from fastapi import HTTPException
 
@@ -210,55 +209,15 @@ def fetch_inferred_parameters(parameters_id: Optional[str], job_id):
 
 def get_result_summary(data_result):
     try:
-        column_headers = data_result.columns
-        timepoint_id_set = list(set(data_result["timepoint_id"].to_list()))
-        timepoint_id_set.sort()
-        sample_id_set = list(set(data_result["sample_id"].to_list()))
-        sample_id_set.sort()
-        summary_result = [
-            ["", "bins", "min_value", "max_value", "mean", "median", "std"]
-        ]
-        for i in sample_id_set:
-            from_index = (i * timepoint_id_set[-1]) + i
-            to_index = (i + 1) * timepoint_id_set[-1] + i
-            for col_name in column_headers:
-                series_row = get_csv_column_stats(
-                    data_result[from_index:to_index][col_name]
-                )
-                series_row.insert(0, col_name)
-                series_row.insert(0, "sample_id: " + str(i))
-                summary_result.append(series_row)
-
-        return summary_result
+        df2 = data_result.groupby("timepoint_id", as_index=False).agg(
+            ["min", "max", "mean", "median", "std"]
+        )
+        df2 = df2.drop(columns=["sample_id", "timepoint_unknown"])
+        df2.columns = ["_".join(i) for i in df2.columns]
+        return df2
     # If the format of the data_result does not match expected column names ect just throw error
     except:
         raise
-
-
-def get_csv_column_stats(column):
-    column = column.to_list()
-    column.sort()
-    min_value = column[0]
-    max_value = column[-1]
-    mean = sum(column) / len(column)
-    median = column[len(column) // 2]
-    std = np.std(column)
-
-    # set up bins:
-    bin_count = 10
-    step_size = (max_value - min_value) / (bin_count - 1)
-    bins = []
-    if step_size == 0:
-        # Every value is the same, so just return a single bin
-        bins = [len(column)]
-    else:
-        bins = [0] * bin_count
-        # Fill bins
-        for i in column:
-            bin_index = int(abs(i - min_value) // step_size)
-            bins[bin_index] += 1
-
-    return [bins, min_value, max_value, mean, median, std]
 
 
 def attach_files(output: dict, job_id, status="complete"):


### PR DESCRIPTION
# Description
Add result_summary.csv when we get a result.csv
This is a convenient place to add these stats and will allow the HMI to utilize these stats in a more clean way


# Testing
Running forecast jobs

Samples:
[result.csv](https://github.com/user-attachments/files/16070630/result.5.csv)
[result_summary.csv](https://github.com/user-attachments/files/16070631/result_summary.2.csv)



