### PR TITLE
updating converter to correctly type.

### DIFF
--- a/service/models/converters.py
+++ b/service/models/converters.py
@@ -11,7 +11,16 @@ def fetch_and_convert_static_interventions(policy_intervention_id, job_id):
     if not (policy_intervention_id):
         return defaultdict(dict)
     policy_intervention = fetch_interventions(policy_intervention_id, job_id)
-    interventionList = policy_intervention["interventions"]
+    interventionList: list[HMIIntervention] = []
+    for inter in policy_intervention["interventions"]:
+        intervention = HMIIntervention(
+            name=inter["name"],
+            applied_to=inter["applied_to"],
+            type=inter["type"],
+            static_interventions=inter["static_interventions"],
+            dynamic_interventions=inter["dynamic_interventions"],
+        )
+        interventionList.append(intervention)
     return convert_static_interventions(interventionList)
 
 
@@ -21,10 +30,10 @@ def convert_static_interventions(interventions: list[HMIIntervention]):
         return defaultdict(dict)
     static_interventions: Dict[torch.Tensor, Dict[str, any]] = defaultdict(dict)
     for inter in interventions:
-        for static_inter in inter["static_interventions"]:
-            time = torch.tensor(float(static_inter["timestep"]))
-            parameter_name = inter["applied_to"]
-            value = torch.tensor(float(static_inter["value"]))
+        for static_inter in inter.static_interventions:
+            time = torch.tensor(float(static_inter.timestep))
+            parameter_name = inter.applied_to
+            value = torch.tensor(float(static_inter.value))
             static_interventions[time][parameter_name] = value
     return static_interventions
 


### PR DESCRIPTION
# Description
There was an issue when providing static interventions via optimize to `convert_static_interventions`
This was that i was using ["field_name"] instead of .field_name

Fixing this caused an issue when calling `fetch_and_convert_static_interventions` as the fetch does not type the payload and just sends it as a dictionary.
This now types prior to the convert step.

# Testing:
Running with no interventions
With interventions that only include static
With interventions that include multiple per static.

![image](https://github.com/user-attachments/assets/6b7a093d-5491-4003-a1b7-68de48204aca)
