### PR TITLE
updating pyciemss hash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ httpx = "^0.24.1"
 
 
 [tool.poe.tasks]
-install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@672201f44752e40ed3a92a335ada136bc30f776e --use-pep517"
+install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@adeb6b974746f86b20597e3d037041121e8ac9c9 --use-pep517"
 
 
 [tool.pytest.ini_options]

--- a/service/models/base.py
+++ b/service/models/base.py
@@ -51,7 +51,6 @@ class HMIDynamicIntervention(BaseModel):
     parameter: str
     threshold: float
     value: float
-    is_greater_than: bool
 
 
 class HMIInterventionPolicy(BaseModel):


### PR DESCRIPTION
# Description
Pyciemss team have made some updates to the optimize feature.
After some testing these optimize changes do not seem breaking

also removing `is_greater_than` from dynamic interventions as it is currently not being utilized. 
