### PR TITLE
Optimize - remove qoi context string manipulation, update ciemss version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ httpx = "^0.24.1"
 
 
 [tool.poe.tasks]
-install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@f5c5bec731441377b845a3b702f01927113bf462 --use-pep517"
+install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@83c974a8fb7ae089fd4e46554fe726b4737a44e8 --use-pep517"
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ httpx = "^0.24.1"
 
 
 [tool.poe.tasks]
-install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@83c974a8fb7ae089fd4e46554fe726b4737a44e8 --use-pep517"
+install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@e224fd5737e96a7a64ed9b0512ca4084eb7a4c87 --use-pep517"
 
 
 [tool.pytest.ini_options]

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -28,7 +28,7 @@ class QOI(BaseModel):
     contexts: List[str] = []
 
     def gen_call(self):
-        contexts = [context + "_state" for context in self.contexts]
+        contexts = self.contexts
         qoi_map = {
             QOIMethod.day_average: lambda samples: obs_nday_average_qoi(
                 samples, contexts, 1

--- a/tests/examples/optimize/input/request.json
+++ b/tests/examples/optimize/input/request.json
@@ -15,7 +15,7 @@
 		"end": 90
 	},
 	"qoi": {
-		"contexts": ["Infected"],
+		"contexts": ["Infected_state"],
 		"method": "day_average"
 	},
 	"risk_bound": 10.0,


### PR DESCRIPTION
# Description

- [x] removing qoi context string manipulation as we need to add `_state` or `_observable` depending on the selection. It is much easier to do this string manip in the hmi-client as it readily has the model while setting up the dropdown options
- [x] Update pyciemss version

Related + required:
https://github.com/DARPA-ASKEM/terarium/pull/4564 

# Testing
-Testing via HMI optimize drilldown.
-running ciemss notebooks locally to ensure sending qoi, risk_bound, and alpha as non lists is caught properly by
https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py#L876-L881 

# Pyciemss updates:
https://github.com/ciemss/pyciemss/pull/596 -> Allows for multiple constraints, contains backwards compatibility 
https://github.com/ciemss/pyciemss/pull/602 -> The changes required for this specific PR
https://github.com/ciemss/pyciemss/pull/592 -> Allows for intermediate results