### PR TITLE
Update interventions to have distinct param and state.

### DIFF
--- a/service/models/converters.py
+++ b/service/models/converters.py
@@ -9,7 +9,7 @@ from models.base import HMIIntervention
 
 def fetch_and_convert_static_interventions(policy_intervention_id, job_id):
     if not (policy_intervention_id):
-        return defaultdict(dict)
+        return defaultdict(dict), defaultdict(dict)
     policy_intervention = fetch_interventions(policy_intervention_id, job_id)
     interventionList: list[HMIIntervention] = []
     for inter in policy_intervention["interventions"]:
@@ -26,7 +26,7 @@ def fetch_and_convert_static_interventions(policy_intervention_id, job_id):
 
 def fetch_and_convert_dynamic_interventions(policy_intervention_id, job_id):
     if not (policy_intervention_id):
-        return defaultdict(dict)
+        return defaultdict(dict), defaultdict(dict)
     policy_intervention = fetch_interventions(policy_intervention_id, job_id)
     interventionList: list[HMIIntervention] = []
     for inter in policy_intervention["interventions"]:
@@ -44,15 +44,22 @@ def fetch_and_convert_dynamic_interventions(policy_intervention_id, job_id):
 # Used to convert from HMI Intervention Policy -> pyciemss static interventions.
 def convert_static_interventions(interventions: list[HMIIntervention]):
     if not (interventions):
-        return defaultdict(dict)
-    static_interventions: Dict[torch.Tensor, Dict[str, any]] = defaultdict(dict)
+        return defaultdict(dict), defaultdict(dict)
+    static_param_interventions: Dict[torch.Tensor, Dict[str, any]] = defaultdict(dict)
+    static_state_interventions: Dict[torch.Tensor, Dict[str, any]] = defaultdict(dict)
     for inter in interventions:
         for static_inter in inter.static_interventions:
-            time = torch.tensor(float(static_inter.timestep))
-            parameter_name = inter.applied_to
-            value = torch.tensor(float(static_inter.value))
-            static_interventions[time][parameter_name] = value
-    return static_interventions
+            if inter.type == "parameter":
+                time = torch.tensor(float(static_inter.timestep))
+                parameter_name = inter.applied_to
+                value = torch.tensor(float(static_inter.value))
+                static_param_interventions[time][parameter_name] = value
+            if inter.type == "state":
+                time = torch.tensor(float(static_inter.timestep))
+                parameter_name = inter.applied_to
+                value = torch.tensor(float(static_inter.value))
+                static_state_interventions[time][parameter_name] = value
+    return static_param_interventions, static_state_interventions
 
 
 # Define the threshold for when the intervention should be applied.
@@ -68,24 +75,39 @@ def make_var_threshold(var: str, threshold: torch.Tensor):
 # Used to convert from HMI Intervention Policy -> pyciemss dynamic interventions.
 def convert_dynamic_interventions(interventions: list[HMIIntervention]):
     if not (interventions):
-        return defaultdict(dict)
+        return defaultdict(dict), defaultdict(dict)
     dynamic_parameter_interventions: Dict[
+        Callable[[torch.Tensor, Dict[str, torch.Tensor]], torch.Tensor],
+        Dict[str, any],
+    ] = defaultdict(dict)
+    dynamic_state_interventions: Dict[
         Callable[[torch.Tensor, Dict[str, torch.Tensor]], torch.Tensor],
         Dict[str, any],
     ] = defaultdict(dict)
     for inter in interventions:
         for dynamic_inter in inter.dynamic_interventions:
-            parameter_name = inter.applied_to
-            threshold_value = torch.tensor(float(dynamic_inter.threshold))
-            to_value = torch.tensor(float(dynamic_inter.value))
-            threshold_func = make_var_threshold(
-                dynamic_inter.parameter, threshold_value
-            )
-            dynamic_parameter_interventions[threshold_func].update(
-                {parameter_name: to_value}
-            )
+            if inter.type == "parameter":
+                parameter_name = inter.applied_to
+                threshold_value = torch.tensor(float(dynamic_inter.threshold))
+                to_value = torch.tensor(float(dynamic_inter.value))
+                threshold_func = make_var_threshold(
+                    dynamic_inter.parameter, threshold_value
+                )
+                dynamic_parameter_interventions[threshold_func].update(
+                    {parameter_name: to_value}
+                )
+            if inter.type == "state":
+                parameter_name = inter.applied_to
+                threshold_value = torch.tensor(float(dynamic_inter.threshold))
+                to_value = torch.tensor(float(dynamic_inter.value))
+                threshold_func = make_var_threshold(
+                    dynamic_inter.parameter, threshold_value
+                )
+                dynamic_state_interventions[threshold_func].update(
+                    {parameter_name: to_value}
+                )
 
-    return dynamic_parameter_interventions
+    return dynamic_parameter_interventions, dynamic_state_interventions
 
 
 def convert_to_solution_mapping(config):

--- a/service/models/converters.py
+++ b/service/models/converters.py
@@ -49,15 +49,12 @@ def convert_static_interventions(interventions: list[HMIIntervention]):
     static_state_interventions: Dict[torch.Tensor, Dict[str, any]] = defaultdict(dict)
     for inter in interventions:
         for static_inter in inter.static_interventions:
+            time = torch.tensor(float(static_inter.timestep))
+            parameter_name = inter.applied_to
+            value = torch.tensor(float(static_inter.value))
             if inter.type == "parameter":
-                time = torch.tensor(float(static_inter.timestep))
-                parameter_name = inter.applied_to
-                value = torch.tensor(float(static_inter.value))
                 static_param_interventions[time][parameter_name] = value
             if inter.type == "state":
-                time = torch.tensor(float(static_inter.timestep))
-                parameter_name = inter.applied_to
-                value = torch.tensor(float(static_inter.value))
                 static_state_interventions[time][parameter_name] = value
     return static_param_interventions, static_state_interventions
 
@@ -86,23 +83,17 @@ def convert_dynamic_interventions(interventions: list[HMIIntervention]):
     ] = defaultdict(dict)
     for inter in interventions:
         for dynamic_inter in inter.dynamic_interventions:
+            parameter_name = inter.applied_to
+            threshold_value = torch.tensor(float(dynamic_inter.threshold))
+            to_value = torch.tensor(float(dynamic_inter.value))
+            threshold_func = make_var_threshold(
+                dynamic_inter.parameter, threshold_value
+            )
             if inter.type == "parameter":
-                parameter_name = inter.applied_to
-                threshold_value = torch.tensor(float(dynamic_inter.threshold))
-                to_value = torch.tensor(float(dynamic_inter.value))
-                threshold_func = make_var_threshold(
-                    dynamic_inter.parameter, threshold_value
-                )
                 dynamic_parameter_interventions[threshold_func].update(
                     {parameter_name: to_value}
                 )
             if inter.type == "state":
-                parameter_name = inter.applied_to
-                threshold_value = torch.tensor(float(dynamic_inter.threshold))
-                to_value = torch.tensor(float(dynamic_inter.value))
-                threshold_func = make_var_threshold(
-                    dynamic_inter.parameter, threshold_value
-                )
                 dynamic_state_interventions[threshold_func].update(
                     {parameter_name: to_value}
                 )

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -90,7 +90,7 @@ class Optimize(OperationRequest):
     model_config_id: str = Field(..., example="ba8da8d4-047d-11ee-be56")
     timespan: Timespan = Timespan(start=0, end=90)
     optimize_interventions: InterventionObjective  # These are the interventions to be optimized.
-    fixed_static_parameter_interventions: list[HMIIntervention] = Field(
+    fixed_interventions: list[HMIIntervention] = Field(
         None
     )  # Theses are interventions provided that will not be optimized
     logging_step_size: float = 1.0
@@ -105,9 +105,10 @@ class Optimize(OperationRequest):
     def gen_pyciemss_args(self, job_id):
         # Get model from TDS
         amr_path = fetch_model(self.model_config_id, job_id)
-        fixed_static_parameter_interventions = convert_static_interventions(
-            self.fixed_static_parameter_interventions
-        )
+        (
+            fixed_static_parameter_interventions,
+            fixed_static_state_interventions,
+        ) = convert_static_interventions(self.fixed_interventions)
 
         intervention_type = self.optimize_interventions.intervention_type
         if intervention_type == "param_value":
@@ -166,6 +167,7 @@ class Optimize(OperationRequest):
             "bounds_interventions": self.bounds_interventions,
             "static_parameter_interventions": optimize_interventions,
             "fixed_static_parameter_interventions": fixed_static_parameter_interventions,
+            # "fixed_static_state_interventions": fixed_static_state_interventions, Does not exist?
             "inferred_parameters": inferred_parameters,
             "n_samples_ouu": n_samples_ouu,
             "solver_method": solver_method,

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -167,7 +167,8 @@ class Optimize(OperationRequest):
             "bounds_interventions": self.bounds_interventions,
             "static_parameter_interventions": optimize_interventions,
             "fixed_static_parameter_interventions": fixed_static_parameter_interventions,
-            # "fixed_static_state_interventions": fixed_static_state_interventions, Does not exist?
+            # https://github.com/DARPA-ASKEM/terarium/issues/4612
+            # "fixed_static_state_interventions": fixed_static_state_interventions,
             "inferred_parameters": inferred_parameters,
             "n_samples_ouu": n_samples_ouu,
             "solver_method": solver_method,

--- a/service/models/operations/simulate.py
+++ b/service/models/operations/simulate.py
@@ -49,13 +49,15 @@ class Simulate(OperationRequest):
         # Get model from TDS
         amr_path = fetch_model(self.model_config_id, job_id)
 
-        static_interventions = fetch_and_convert_static_interventions(
-            self.policy_intervention_id, job_id
-        )
+        (
+            static_param_interventions,
+            static_state_interventions,
+        ) = fetch_and_convert_static_interventions(self.policy_intervention_id, job_id)
 
-        dynamic_interventions = fetch_and_convert_dynamic_interventions(
-            self.policy_intervention_id, job_id
-        )
+        (
+            dynamic_param_interventions,
+            dynamic_state_interventions,
+        ) = fetch_and_convert_dynamic_interventions(self.policy_intervention_id, job_id)
 
         extra_options = self.extra.dict()
         inferred_parameters = fetch_inferred_parameters(
@@ -75,8 +77,10 @@ class Simulate(OperationRequest):
             "logging_step_size": self.logging_step_size,
             "start_time": self.timespan.start,
             "end_time": self.timespan.end,
-            "static_parameter_interventions": static_interventions,
-            "dynamic_parameter_interventions": dynamic_interventions,
+            "static_parameter_interventions": static_param_interventions,
+            "static_state_interventions": static_state_interventions,
+            "dynamic_parameter_interventions": dynamic_param_interventions,
+            "dynamic_state_interventions": dynamic_state_interventions,
             "inferred_parameters": inferred_parameters,
             "solver_method": solver_method,
             "solver_options": solver_options,


### PR DESCRIPTION
# Description

The interfaces in ciemss utilize different inputs for state and parameter interventions.
https://github.com/ciemss/pyciemss/blob/main/pyciemss/interfaces.py

This PR addresses this and corrects the converter in pyciemss-service.

![image](https://github.com/user-attachments/assets/132daec8-4c03-432d-b21c-46129eb2cabd)

