### PR TITLE
Optimize utilize intermediate results

### DIFF
--- a/service/models/operations/calibrate.py
+++ b/service/models/operations/calibrate.py
@@ -13,7 +13,7 @@ from models.converters import (
     fetch_and_convert_static_interventions,
     fetch_and_convert_dynamic_interventions,
 )
-from utils.rabbitmq import gen_rabbitmq_hook
+from utils.rabbitmq import gen_calibrate_rabbitmq_hook
 from utils.tds import fetch_dataset, fetch_model
 
 
@@ -77,7 +77,7 @@ class Calibrate(OperationRequest):
 
         # TODO: Test RabbitMQ
         try:
-            hook = gen_rabbitmq_hook(job_id)
+            hook = gen_calibrate_rabbitmq_hook(job_id)
         except (socket.gaierror, AMQPConnectionError):
             logging.warning(
                 "%s: Failed to connect to RabbitMQ. Unable to log progress", job_id

--- a/service/models/operations/ensemble_calibrate.py
+++ b/service/models/operations/ensemble_calibrate.py
@@ -11,7 +11,7 @@ from pika.exceptions import AMQPConnectionError
 
 from models.base import Dataset, OperationRequest, Timespan, ModelConfig
 from models.converters import convert_to_solution_mapping
-from utils.rabbitmq import gen_rabbitmq_hook
+from utils.rabbitmq import gen_calibrate_rabbitmq_hook
 from utils.tds import fetch_dataset, fetch_model
 
 
@@ -52,7 +52,7 @@ class EnsembleCalibrate(OperationRequest):
         dataset_path = fetch_dataset(self.dataset.dict(), job_id)
 
         try:
-            hook = gen_rabbitmq_hook(job_id)
+            hook = gen_calibrate_rabbitmq_hook(job_id)
         except (socket.gaierror, AMQPConnectionError):
             logging.warning(
                 "%s: Failed to connect to RabbitMQ. Unable to log progress", job_id

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import ClassVar, List, Optional
 from enum import Enum
+from utils.rabbitmq import OptimizeHook
 
 import numpy as np
 import torch
@@ -151,6 +152,11 @@ class Optimize(OperationRequest):
         if step_size is not None and solver_method == "euler":
             solver_options["step_size"] = step_size
 
+        total_possible_iterations = extra_options.get("maxiter") * extra_options.get(
+            "maxfeval"
+        )
+        progress_hook = OptimizeHook(job_id, total_possible_iterations)
+
         return {
             "model_path_or_json": amr_path,
             "logging_step_size": self.logging_step_size,
@@ -173,6 +179,7 @@ class Optimize(OperationRequest):
             "n_samples_ouu": n_samples_ouu,
             "solver_method": solver_method,
             "solver_options": solver_options,
+            "progress_hook": progress_hook,
             **extra_options,
         }
 

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -152,9 +152,9 @@ class Optimize(OperationRequest):
         if step_size is not None and solver_method == "euler":
             solver_options["step_size"] = step_size
 
-        total_possible_iterations = extra_options.get("maxiter") * extra_options.get(
-            "maxfeval"
-        )
+        total_possible_iterations = (
+            extra_options.get("maxiter") + 1
+        ) * extra_options.get("maxfeval")
         progress_hook = OptimizeHook(job_id, total_possible_iterations)
 
         return {

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -166,6 +166,10 @@ class Optimize(OperationRequest):
                 "%s: Failed to connect to RabbitMQ. Unable to log progress", job_id
             )
 
+            # Log progress hook when unable to connect - for testing purposes.
+            def progress_hook(current_results):
+                logging.info(f"Optimize current results: {current_results.tolist()}")
+
         return {
             "model_path_or_json": amr_path,
             "logging_step_size": self.logging_step_size,

--- a/service/utils/rabbitmq.py
+++ b/service/utils/rabbitmq.py
@@ -83,16 +83,6 @@ class OptimizeHook:
 
     def __call__(self, current_results):
         self.step += 1
-        print(
-            "job_id: ",
-            self.job_id,
-            " progress: ",
-            self.step,
-            " current_results: ",
-            current_results.tolist(),
-            " total_possible_iterations: ",
-            self.total_possible_iterations,
-        )
         self.channel.basic_publish(
             exchange="",
             routing_key="simulation-status",

--- a/service/utils/rabbitmq.py
+++ b/service/utils/rabbitmq.py
@@ -52,7 +52,7 @@ def mock_rabbitmq_consumer():
     channel.start_consuming()
 
 
-def gen_rabbitmq_hook(job_id):
+def gen_calibrate_rabbitmq_hook(job_id):
     connection = pika.BlockingConnection(
         conn_config,
     )
@@ -68,3 +68,40 @@ def gen_rabbitmq_hook(job_id):
         )
 
     return hook
+
+
+class OptimizeHook:
+    def __init__(self, job_id, total_possible_iterations):
+        connection = pika.BlockingConnection(
+            conn_config,
+        )
+        self.channel = connection.channel()
+        self.job_id = job_id
+        self.result = []
+        self.step = 0
+        self.total_possible_iterations = total_possible_iterations
+
+    def __call__(self, current_results):
+        self.step += 1
+        print(
+            "job_id: ",
+            self.job_id,
+            " progress: ",
+            self.step,
+            " current_results: ",
+            current_results.tolist(),
+            " total_possible_iterations: ",
+            self.total_possible_iterations,
+        )
+        self.channel.basic_publish(
+            exchange="",
+            routing_key="simulation-status",
+            body=json.dumps(
+                {
+                    "job_id": self.job_id,
+                    "progress": self.step,
+                    "current_results": current_results.tolist(),
+                    "total_possible_iterations": self.total_possible_iterations,
+                }
+            ),
+        )

--- a/service/utils/rabbitmq.py
+++ b/service/utils/rabbitmq.py
@@ -63,7 +63,12 @@ def gen_calibrate_rabbitmq_hook(job_id):
             exchange="",
             routing_key="simulation-status",
             body=json.dumps(
-                {"job_id": job_id, "progress": progress, "loss": str(loss)}
+                {
+                    "job_id": job_id,
+                    "type": "calibrate",
+                    "progress": progress,
+                    "loss": str(loss),
+                }
             ),
         )
 
@@ -77,6 +82,7 @@ class OptimizeHook:
         )
         self.channel = connection.channel()
         self.job_id = job_id
+        self.type = "optimize"
         self.result = []
         self.step = 0
         self.total_possible_iterations = total_possible_iterations
@@ -90,6 +96,7 @@ class OptimizeHook:
                 {
                     "job_id": self.job_id,
                     "progress": self.step,
+                    "type": self.type,
                     "current_results": current_results.tolist(),
                     "total_possible_iterations": self.total_possible_iterations,
                 }


### PR DESCRIPTION
# Description

- Renaming calibrate's hook to contain the word calibrate as it is not generic.
- Create a new hook for optimize 
- Utilizing optimize's progress hook to send messages in the form: `{" job_id": ID, "type": "optimize", "progress": number, "current_results": number[], "total_possible_iterations": number }`

# Utilized with
https://github.com/DARPA-ASKEM/terarium/pull/4745


