### PR TITLE
Pyciemss optimize multiple constraints

### DIFF
--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import ClassVar, List, Optional
+from typing import ClassVar, List, Optional, Union
 from enum import Enum
 
 import numpy as np
@@ -75,7 +75,7 @@ class OptimizeExtra(BaseModel):
     )
     maxiter: int = 5
     maxfeval: int = 25
-    alpha: float = 0.95
+    alpha: Union[List[float], float] = 0.95
     solver_method: str = "dopri5"
     # https://github.com/ciemss/pyciemss/blob/main/pyciemss/integration_utils/interface_checks.py
     solver_step_size: float = Field(
@@ -94,7 +94,7 @@ class Optimize(OperationRequest):
         None
     )  # Theses are interventions provided that will not be optimized
     logging_step_size: float = 1.0
-    qoi: QOI
+    qoi: list[QOI]
     risk_bound: float
     bounds_interventions: List[List[float]]
     extra: OptimizeExtra = Field(

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -185,10 +185,10 @@ class Optimize(OperationRequest):
             def progress_hook(current_results):
                 logging.info(f"Optimize current results: {current_results.tolist()}")
 
-        qois = []
+        qoi_methods = []
         risk_bounds = []
         for qoi in self.qoi:
-            qois.append(qoi.gen_call())
+            qoi_methods.append(qoi.gen_call())
             risk_bounds.append(qoi.gen_risk_bound())
 
         return {
@@ -201,7 +201,7 @@ class Optimize(OperationRequest):
                 self.optimize_interventions.initial_guess[0],
                 self.optimize_interventions.objective_function_option[0],
             ),
-            "qoi": qois,
+            "qoi": qoi_methods,
             "risk_bound": risk_bounds,
             "initial_guess_interventions": self.optimize_interventions.initial_guess,
             "bounds_interventions": self.bounds_interventions,

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -95,7 +95,7 @@ class Optimize(OperationRequest):
     )  # Theses are interventions provided that will not be optimized
     logging_step_size: float = 1.0
     qoi: list[QOI]
-    risk_bound: float
+    risk_bound: list[float]
     bounds_interventions: List[List[float]]
     extra: OptimizeExtra = Field(
         None,
@@ -151,6 +151,10 @@ class Optimize(OperationRequest):
         if step_size is not None and solver_method == "euler":
             solver_options["step_size"] = step_size
 
+        qois = []
+        for qoi in self.qoi:
+            qois.append(qoi.gen_call())
+
         return {
             "model_path_or_json": amr_path,
             "logging_step_size": self.logging_step_size,
@@ -161,7 +165,7 @@ class Optimize(OperationRequest):
                 self.optimize_interventions.initial_guess[0],
                 self.optimize_interventions.objective_function_option[0],
             ),
-            "qoi": self.qoi.gen_call(),
+            "qoi": qois,
             "risk_bound": self.risk_bound,
             "initial_guess_interventions": self.optimize_interventions.initial_guess,
             "bounds_interventions": self.bounds_interventions,

--- a/tests/examples/optimize/input/request.json
+++ b/tests/examples/optimize/input/request.json
@@ -16,12 +16,12 @@
 	},
 	"qoi": {
 		"contexts": ["Infected_state"],
-		"method": "day_average"
+		"method": "day_average",
+		"risk_bound": 10.0,
+		"is_minimized": true
 	},
-	"risk_bound": 10.0,
   "bounds_interventions": [[0.0], [3.0]],
 	"extra": {
-		"num_samples": 4,
-		"is_minimized": true
+		"num_samples": 4
 	}
 }

--- a/tests/examples/optimize/input/request.json
+++ b/tests/examples/optimize/input/request.json
@@ -14,12 +14,12 @@
 		"start": 0,
 		"end": 90
 	},
-	"qoi": {
+	"qoi": [{
 		"contexts": ["Infected_state"],
 		"method": "day_average",
 		"risk_bound": 10.0,
 		"is_minimized": true
-	},
+	}],
   "bounds_interventions": [[0.0], [3.0]],
 	"extra": {
 		"num_samples": 4


### PR DESCRIPTION
# Description
Updating pyciemss interface to allow for multiple constraints.
This means the follow must become lists (of the same length):

- alpha
- qoi
- riskbound

# Utilized by:
https://github.com/DARPA-ASKEM/terarium/pull/4775