### PR TITLE
Optimize: Update obj func

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -3,11 +3,11 @@ networks:
   pyciemss:
     driver: bridge
     name: pyciemss
-  terarium:
+  data-api:
     external: true
 services:
   api:
-    container_name: pyciemss-api-ciemss
+    container_name: pyciemss-api
     build:
       context: ..
       dockerfile: docker/Dockerfile.api
@@ -17,32 +17,59 @@ services:
       - ../.env
     networks:
       - pyciemss
-      - terarium
+      - data-api
+    depends_on:
+      - redis
+      - rabbitmq
     volumes:
       - $PWD/service:/service
     extra_hosts:
       - "host.docker.internal:host-gateway"
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - "6379:6379"
+    networks:
+      - pyciemss
   rqworker:
-    container_name: pyciemss-worker-ciemss
+    container_name: pyciemss-worker
     build:
       context: ..
       dockerfile: docker/Dockerfile.worker
     env_file:
       - ../.env
     depends_on:
+      - redis
       - api
     networks:
+      - data-api
       - pyciemss
-      - terarium
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-  redis:
-    container_name: redis-ciemss
-    image: redis:7-alpine
+  rabbitmq:
+    container_name: rabbitmq
+    profiles: ["standalone"]
+    hostname: rabbitmq
+    image: 'rabbitmq:3'
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     ports:
-      - "6666:6379"
-
-
-
-
-
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - pyciemss
+  rabbitmq-mock-consumer:
+    container_name: rabbitmq-mock-consumer
+    profiles: ["standalone"]
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.api
+    command: poetry run mockrabbitmq
+    env_file:
+      - ../.env
+    networks:
+      - pyciemss
+    depends_on:
+      - rabbitmq

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -32,8 +32,8 @@ class InterventionType(str, Enum):
 
 
 class InterventionObjectiveFunction(str, Enum):
-    lower_bound = ("lower_bound",)
-    upper_bound = ("upper_bound",)
+    lower_bound = "lower_bound"
+    upper_bound = "upper_bound"
     initial_guess = "initial_guess"
 
 

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -25,6 +25,12 @@ from models.converters import convert_static_interventions
 from utils.tds import fetch_model, fetch_inferred_parameters
 
 
+class InterventionType(str, Enum):
+    param_value = "param_value"
+    start_time = "start_time"
+    start_time_param_value = "start_time_param_value"
+
+
 class QOIMethod(str, Enum):
     day_average = "day_average"
     max = "max"
@@ -113,8 +119,8 @@ def objfun(x, optimize_interventions: list[InterventionObjective]):
 
 
 class InterventionObjective(BaseModel):
-    intervention_type: str = Field(
-        "param_value",
+    intervention_type: InterventionType = Field(
+        InterventionType.param_value,
         description="The intervention objective to use",
         example="param_value",
     )
@@ -184,7 +190,7 @@ class Optimize(OperationRequest):
         for i in range(len(self.optimize_interventions)):
             currentIntervention = self.optimize_interventions[i]
             intervention_type = currentIntervention.intervention_type
-            if intervention_type == "param_value":
+            if intervention_type == InterventionType.param_value:
                 assert currentIntervention.start_time is not None
                 start_time = [
                     torch.tensor(time) for time in currentIntervention.start_time
@@ -199,7 +205,7 @@ class Optimize(OperationRequest):
                     )
                 )
                 intervention_func_lengths.append(1)
-            if intervention_type == "start_time":
+            if intervention_type == InterventionType.start_time:
                 assert currentIntervention.param_values is not None
                 param_value = [
                     torch.tensor(value) for value in currentIntervention.param_values
@@ -211,7 +217,7 @@ class Optimize(OperationRequest):
                     )
                 )
                 intervention_func_lengths.append(1)
-            if intervention_type == "start_time_param_value":
+            if intervention_type == InterventionType.start_time_param_value:
                 transformed_optimize_interventions.append(
                     start_time_param_value_objective(
                         param_name=currentIntervention.param_names

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import ClassVar, List, Optional, Union
+from typing import ClassVar, List, Optional, Union, Callable, Dict
+from chirho.interventional.ops import Intervention
 from enum import Enum
 from utils.rabbitmq import OptimizeHook
 from pika.exceptions import AMQPConnectionError
@@ -13,6 +14,7 @@ import torch
 from pydantic import BaseModel, Field, Extra
 from models.base import OperationRequest, Timespan, HMIIntervention
 from pyciemss.integration_utils.intervention_builder import (
+    intervention_func_combinator,
     param_value_objective,
     start_time_objective,
     start_time_param_value_objective,
@@ -59,15 +61,13 @@ class QOI(BaseModel):
             return -self.risk_bound
 
 
-def objfun(x, initial_guess, objective_function_option, relative_importance):
+def objfun(x, optimize_interventions: list[InterventionObjective]):
     """
     Calculate the weighted sum of objective functions based on the given parameters.
 
     Parameters:
     x (list): The current values of the variables.
-    initial_guess (list): The initial guess values of the variables.
-    objective_function_option (list): List of options specifying the type of objective function for each variable.
-    relative_importance (list): List of weights indicating the relative importance of each variable.
+    optimize_interventions: The interventions which are being optimized over
 
     Returns:
     float: The weighted sum of the objective functions.
@@ -75,7 +75,12 @@ def objfun(x, initial_guess, objective_function_option, relative_importance):
 
     # Initialize the total sum to zero
     total_sum = 0
-
+    # TODO: Will be cleaning this up in the next PR. I want minimal changes per PR for readability.
+    relative_importance = [i.relative_importance for i in optimize_interventions]
+    initial_guess = [i.initial_guess for i in optimize_interventions]
+    objective_function_option = [
+        i.objective_function_option for i in optimize_interventions
+    ]
     # Calculate the sum of all weights, fallback to 1 if the sum is 0
     sum_of_all_weights = np.sum(relative_importance) or 1
 
@@ -116,9 +121,9 @@ class InterventionObjective(BaseModel):
     param_names: list[str]
     param_values: Optional[list[Optional[float]]] = None
     start_time: Optional[list[float]] = None
-    objective_function_option: Optional[list[str]] = None
+    objective_function_option: Optional[str] = None
     initial_guess: Optional[list[float]] = None
-    relative_importance: Optional[list[float]] = None
+    relative_importance: Optional[float] = None
 
 
 class OptimizeExtra(BaseModel):
@@ -150,7 +155,9 @@ class Optimize(OperationRequest):
     pyciemss_lib_function: ClassVar[str] = "optimize"
     model_config_id: str = Field(..., example="ba8da8d4-047d-11ee-be56")
     timespan: Timespan = Timespan(start=0, end=90)
-    optimize_interventions: InterventionObjective  # These are the interventions to be optimized.
+    optimize_interventions: list[
+        InterventionObjective
+    ]  # These are the interventions to be optimized.
     fixed_interventions: list[HMIIntervention] = Field(
         None
     )  # Theses are interventions provided that will not be optimized
@@ -170,33 +177,43 @@ class Optimize(OperationRequest):
             fixed_static_state_interventions,
         ) = convert_static_interventions(self.fixed_interventions)
 
-        intervention_type = self.optimize_interventions.intervention_type
-        if intervention_type == "param_value":
-            assert self.optimize_interventions.start_time is not None
-            start_time = [
-                torch.tensor(time) for time in self.optimize_interventions.start_time
-            ]
-            param_value = [None] * len(self.optimize_interventions.param_names)
+        transformed_optimize_interventions: list[
+            Callable[[torch.Tensor], Dict[float, Dict[str, Intervention]]]
+        ] = []
+        for i in range(len(self.optimize_interventions)):
+            currentIntervention = self.optimize_interventions[i]
+            intervention_type = currentIntervention.intervention_type
+            if intervention_type == "param_value":
+                assert currentIntervention.start_time is not None
+                start_time = [
+                    torch.tensor(time) for time in currentIntervention.start_time
+                ]
+                param_value = [None] * len(currentIntervention.param_names)
 
-            optimize_interventions = param_value_objective(
-                start_time=start_time,
-                param_name=self.optimize_interventions.param_names,
-                param_value=param_value,
-            )
-        if intervention_type == "start_time":
-            assert self.optimize_interventions.param_values is not None
-            param_value = [
-                torch.tensor(value)
-                for value in self.optimize_interventions.param_values
-            ]
-            optimize_interventions = start_time_objective(
-                param_name=self.optimize_interventions.param_names,
-                param_value=param_value,
-            )
-        if intervention_type == "start_time_param_value":
-            optimize_interventions = start_time_param_value_objective(
-                param_name=self.optimize_interventions.param_names
-            )
+                transformed_optimize_interventions.append(
+                    param_value_objective(
+                        start_time=start_time,
+                        param_name=currentIntervention.param_names,
+                        param_value=param_value,
+                    )
+                )
+            if intervention_type == "start_time":
+                assert currentIntervention.param_values is not None
+                param_value = [
+                    torch.tensor(value) for value in currentIntervention.param_values
+                ]
+                transformed_optimize_interventions.append(
+                    start_time_objective(
+                        param_name=currentIntervention.param_names,
+                        param_value=param_value,
+                    )
+                )
+            if intervention_type == "start_time_param_value":
+                transformed_optimize_interventions.append(
+                    start_time_param_value_objective(
+                        param_name=currentIntervention.param_names
+                    )
+                )
 
         extra_options = self.extra.dict()
         inferred_parameters = fetch_inferred_parameters(
@@ -231,22 +248,23 @@ class Optimize(OperationRequest):
             qoi_methods.append(qoi.gen_call())
             risk_bounds.append(qoi.gen_risk_bound())
 
+        # TODO: Confirm with ciemss team this is what they intend
+        intervention_func_lengths = [
+            1 for i in range(len(transformed_optimize_interventions))
+        ]
         return {
             "model_path_or_json": amr_path,
             "logging_step_size": self.logging_step_size,
             "start_time": self.timespan.start,
             "end_time": self.timespan.end,
-            "objfun": lambda x: objfun(
-                x,
-                self.optimize_interventions.initial_guess,
-                self.optimize_interventions.objective_function_option,
-                self.optimize_interventions.relative_importance,
-            ),
+            "objfun": lambda x: objfun(x, self.optimize_interventions),
             "qoi": qoi_methods,
             "risk_bound": risk_bounds,
-            "initial_guess_interventions": self.optimize_interventions.initial_guess,
+            "initial_guess_interventions": self.optimize_interventions[0].initial_guess,
             "bounds_interventions": self.bounds_interventions,
-            "static_parameter_interventions": optimize_interventions,
+            "static_parameter_interventions": intervention_func_combinator(
+                transformed_optimize_interventions, intervention_func_lengths
+            ),
             "fixed_static_parameter_interventions": fixed_static_parameter_interventions,
             # https://github.com/DARPA-ASKEM/terarium/issues/4612
             # "fixed_static_state_interventions": fixed_static_state_interventions,

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -31,6 +31,12 @@ class InterventionType(str, Enum):
     start_time_param_value = "start_time_param_value"
 
 
+class InterventionObjectiveFunction(str, Enum):
+    lower_bound = ("lower_bound",)
+    upper_bound = ("upper_bound",)
+    initial_guess = "initial_guess"
+
+
 class QOIMethod(str, Enum):
     day_average = "day_average"
     max = "max"
@@ -107,11 +113,13 @@ def objfun(x, optimize_interventions: list[InterventionObjective]):
         weight = relative_importance[i] / sum_of_all_weights
 
         # Apply the corresponding objective function based on the option provided
-        if objective_function_option[i] == "lower_bound":
+        if objective_function_option[i] == InterventionObjectiveFunction.lower_bound:
             total_sum += weight * np.abs(x[i])
-        elif objective_function_option[i] == "upper_bound":
+        elif objective_function_option[i] == InterventionObjectiveFunction.upper_bound:
             total_sum += weight * -np.abs(x[i])
-        elif objective_function_option[i] == "initial_guess":
+        elif (
+            objective_function_option[i] == InterventionObjectiveFunction.initial_guess
+        ):
             total_sum += weight * np.abs(x[i] - initial_guess[i])
 
     # Return the total weighted sum of the objective functions
@@ -127,7 +135,7 @@ class InterventionObjective(BaseModel):
     param_names: list[str]
     param_values: Optional[list[Optional[float]]] = None
     start_time: Optional[list[float]] = None
-    objective_function_option: Optional[str] = None
+    objective_function_option: Optional[InterventionObjectiveFunction] = None
     initial_guess: Optional[list[float]] = None
     relative_importance: Optional[float] = None
 

--- a/service/models/operations/optimize.py
+++ b/service/models/operations/optimize.py
@@ -79,7 +79,7 @@ def objfun(x, optimize_interventions: list[InterventionObjective]):
 
     Parameters:
     x (list): The current values of the variables.
-    optimize_interventions: The interventions which are being optimized over
+    optimize_interventions: The interventions which are being optimized over.
 
     Returns:
     float: The weighted sum of the objective functions.
@@ -91,13 +91,14 @@ def objfun(x, optimize_interventions: list[InterventionObjective]):
     sum_of_all_weights = (
         np.sum([i.relative_importance for i in optimize_interventions]) or 1.0
     )
-    # Iterate over each variable
+    # Iterate over each intervention
     while len(optimize_interventions) > 0:
         current_intervention = optimize_interventions.pop(0)
         current_weight = current_intervention.relative_importance / sum_of_all_weights
         intervention_type = current_intervention.intervention_type
         obj_function_option = current_intervention.objective_function_option
         initial_guess = current_intervention.initial_guess
+        # The following will have one value therefore we only grab the one value from X.
         if (
             intervention_type == InterventionType.start_time
             or intervention_type == InterventionType.param_value
@@ -109,6 +110,8 @@ def objfun(x, optimize_interventions: list[InterventionObjective]):
                 total_sum += current_weight * -np.abs(x_val)
             elif obj_function_option == InterventionObjectiveFunction.initial_guess:
                 total_sum += current_weight * np.abs(x_val - initial_guess[0])
+        # The following will have two values therefore we grab the two corresponding values for X
+        # Note that start_time_param_value both start time and param value will have the same weight as eachother.
         elif intervention_type == InterventionType.start_time_param_value:
             x_val_one, x = x[0], x[1:]
             x_val_two, x = x[0], x[1:]

--- a/tests/examples/optimize/input/request.json
+++ b/tests/examples/optimize/input/request.json
@@ -2,15 +2,15 @@
 	"engine": "ciemss",
 	"user_id": "not_provided",
 	"model_config_id": "sidarthe",
-	"optimize_interventions": {
+	"optimize_interventions": [{
 		"intervention_type": "param_value",
-		"objective_function_option": ["lower_bound"],
+		"objective_function_option": "lower_bound",
 		"start_time": [2],
 		"param_names": ["beta"],
 		"param_values": [0.02],
 		"initial_guess": [0],
-		"relative_importance": [1]
-	},
+		"relative_importance": 1
+	}],
 	"timespan": {
 		"start": 0,
 		"end": 90


### PR DESCRIPTION
# Description:
- Clean - update many of the loose strings to enums as we know what they are expected to be.
- Fix - Since we have added relative weights using `start_time_param_value` would break our objective function. This was written with the assumption that `length of x` === `length of interventions` but this is not the case when we provide `start_time_param_value` as it will increase interventions by 1 and x by 2

# Testing:
Run optimizes that do not include `start_time_param_value` -> Should pass as before
Run optimizes that do include `start_time_param_value` -> Should now pass 

Example: while running with very minimal iterations and function eval (1-3, 1-3) we expect the result to be at or very close to the initial guess. We therefore expect to the resulting order to be: `1, 20, 0.2, 30`
1st:
<img width="632" alt="image" src="https://github.com/user-attachments/assets/b2a8b31f-2049-4ed4-b198-e6d0502a25e2">

2nd:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/17560dd1-4eb4-4d0a-89db-0c10dbe7e427">

3rd:
<img width="632" alt="image" src="https://github.com/user-attachments/assets/baccff77-db79-41a4-b237-0ac5ba68f2d7">

Result:
<img width="719" alt="image" src="https://github.com/user-attachments/assets/2f2b5410-6090-42a3-9ae9-bd67cb3e8a82">

