### PR TITLE
Keep timepoint_unknown in Result Summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ httpx = "^0.24.1"
 
 
 [tool.poe.tasks]
-install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@bbfa6e12e9daa781dc374804d740c501cd08e6c5 --use-pep517"
+install-pyciemss = "pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@e3d7d2216494bc0217517173520f99f3ba2a03ea --use-pep517"
 
 [tool.pytest.ini_options]
 markers = ["example_dir"]

--- a/service/utils/tds.py
+++ b/service/utils/tds.py
@@ -210,10 +210,10 @@ def fetch_inferred_parameters(parameters_id: Optional[str], job_id):
 
 def get_result_summary(data_result):
     try:
-        df2 = data_result.groupby("timepoint_id", as_index=False).agg(
-            ["min", "max", "mean", "median", "std"]
-        )
-        df2 = df2.drop(columns=["sample_id", "timepoint_unknown"])
+        df2 = data_result.groupby(
+            ["timepoint_id", "timepoint_unknown"], as_index=False
+        ).agg(["min", "max", "mean", "median", "std"])
+        df2 = df2.drop(columns=["sample_id"])
         df2.columns = ["_".join(i) for i in df2.columns]
         df2 = df2.rename(columns={"timepoint_id_": "timepoint_id"})
         return df2

--- a/service/utils/tds.py
+++ b/service/utils/tds.py
@@ -216,6 +216,7 @@ def get_result_summary(data_result):
         df2 = df2.drop(columns=["sample_id"])
         df2.columns = ["_".join(i) for i in df2.columns]
         df2 = df2.rename(columns={"timepoint_id_": "timepoint_id"})
+        df2 = df2.rename(columns={"timepoint_unknown_": "timepoint_unknown"})
         return df2
     # If the format of the data_result does not match expected column names ect just throw error
     except:


### PR DESCRIPTION
# Description
- When dealing with result summary we should keep timepoint_unknown as it now is important.
- We should also group with it so as to not .agg over it
- Also update pyciemss 
